### PR TITLE
Fix resourcePath to allow swagger-codegen tools to work.

### DIFF
--- a/src/ring/swagger/core.clj
+++ b/src/ring/swagger/core.clj
@@ -237,7 +237,7 @@
         resource-defaults
         (select-keys parameters [:apiVersion :produces :consumes])
         {:basePath basepath
-         :resourcePath ""
+         :resourcePath (str "/" api)
          :models (transform-models (extract-models details))
          :apis (for [{:keys [method uri metadata] :as route} (:routes details)
                      :let [{:keys [return summary notes nickname parameters responseMessages]} metadata]]

--- a/test/ring/swagger/core_test.clj
+++ b/test/ring/swagger/core_test.clj
@@ -304,7 +304,7 @@
       ..basepath..) => (has-body {:swaggerVersion "1.2"
                                   :apiVersion "0.0.1"
                                   :basePath ..basepath..
-                                  :resourcePath ""
+                                  :resourcePath (str "/" ..api..)
                                   :produces ["application/json"]
                                   :consumes ["application/json"]
                                   :models {}
@@ -343,7 +343,7 @@
          {:swaggerVersion "1.2"
           :apiVersion ..version..
           :basePath ..basepath..
-          :resourcePath ""
+          :resourcePath (str "/" ..api..)
           :produces ["application/json"
                      "application/xml"]
           :consumes ["application/json"
@@ -399,7 +399,7 @@
            {:swaggerVersion "1.2"
             :apiVersion "0.0.1"
             :basePath ..basepath..
-            :resourcePath ""
+            :resourcePath (str "/" ..api..)
             :produces ["application/json"]
             :consumes ["application/json"]
             :models {}


### PR DESCRIPTION
According to the swagger spec (https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md)
the resourcePath should be:

The relative path to the resource, from the basePath, which this API Specification describes. The value MUST precede with a forward slash ("/").
