### PR TITLE
exclude plumbing.core/update

### DIFF
--- a/src/ring/swagger/core.clj
+++ b/src/ring/swagger/core.clj
@@ -5,7 +5,7 @@
             [ring.swagger.impl :refer :all]
             [schema.core :as s]
             [schema.macros :as sm]
-            [plumbing.core :refer :all]
+            [plumbing.core :refer :all :exclude [update]]
             [schema.utils :as su]
             [ring.swagger.schema :as schema]
             [ring.swagger.coerce :as coerce]


### PR DESCRIPTION
it's not used, and it clobbers clojure.core/update, causing warns under Clojure 1.7
