### PR TITLE
Enable Swagger's OAuth2 support

### DIFF
--- a/src/ring/swagger/core.clj
+++ b/src/ring/swagger/core.clj
@@ -224,6 +224,7 @@
       swagger-defaults
       (select-keys parameters [:apiVersion])
       {:info (select-keys parameters api-declaration-keys)
+       :authorizations (:authorizations parameters {})
        :apis (for [[api details] swagger]
                {:path (str "/" (name api))
                 :description (or (:description details) "")})})))
@@ -239,11 +240,13 @@
          :resourcePath "/"
          :models (transform-models (extract-models details))
          :apis (for [{:keys [method uri metadata] :as route} (:routes details)
-                     :let [{:keys [return summary notes nickname parameters responseMessages]} metadata]]
+                     :let [{:keys [return summary notes nickname parameters
+                                   responseMessages authorizations]} metadata]]
                  {:path (swagger-path uri)
                   :operations [(merge
                                  (jsons/->json return :top true)
                                  {:method (-> method name .toUpperCase)
+                                  :authorizations (or authorizations {})
                                   :summary (or summary "")
                                   :notes (or notes "")
                                   :nickname (or nickname (generate-nick route))

--- a/src/ring/swagger/ui.clj
+++ b/src/ring/swagger/ui.clj
@@ -1,5 +1,6 @@
 (ns ring.swagger.ui
-  (:require [ring.util.response :as response]
+  (:require [cheshire.core :as json]
+            [ring.util.response :as response]
             [ring.middleware.content-type :refer [wrap-content-type]]
             [ring.middleware.not-modified :refer [wrap-not-modified]]
             [ring.middleware.head :refer [wrap-head]]
@@ -8,9 +9,15 @@
 (defn get-path [root uri]
   (second (re-find (re-pattern (str "^" root "[/]?(.*)")) uri)))
 
-(defn conf-js [req {:keys [swagger-docs] :or {swagger-docs "/api/api-docs"}}]
-  (let [swagger-docs (swagger/join-paths (swagger/context req) swagger-docs)]
-    (str "window.API_CONF = {url: \"" swagger-docs "\"};")))
+(defn conf-js [req {:keys [swagger-docs oauth2]
+                    :or {swagger-docs "/api/api-docs"
+                         oauth2 nil}}]
+  (let [swagger-docs (swagger/join-paths (swagger/context req) swagger-docs)
+        conf (cond-> {:url swagger-docs}
+                     oauth2 (assoc :oauth2 {"clientId" (:client-id oauth2)
+                                            "appName" (:app-name oauth2)
+                                            "realm" (:realm oauth2)}))]
+    (str "window.API_CONF = " (json/encode conf) ";")))
 
 (defn swagger-ui
   "This function creates a ring handler which can be used to serve swagger-ui.
@@ -19,7 +26,8 @@
 
    Other options can be given using keyword-value pairs.
    :root - the root prefix to get resources from. Default 'swagger-ui'
-   :swagger-docs - the endpoint to get swagger data from. Default '/api/docs'"
+   :swagger-docs - the endpoint to get swagger data from. Default '/api/docs'
+   :oauth2 - map with oauth2 params, namely :client-id, :realm and :app-name"
   [& params]
   (let [[path kvs] (if (string? (first params))
                      [(first params) (rest params)]

--- a/test/ring/swagger/core_test.clj
+++ b/test/ring/swagger/core_test.clj
@@ -358,7 +358,8 @@
                              {:swaggerVersion "1.2"
                               :apiVersion "0.0.1"
                               :apis []
-                              :info {}}))
+                              :info {}
+                              :authorizations {}}))
   (fact "with parameters"
     (api-listing {:apiVersion ...version...
                   :title ..title..
@@ -375,7 +376,8 @@
                                                                :contact ..contact..
                                                                :license ..licence..
                                                                :licenseUrl ..licenceUrl..}
-                                                        :apis []}))
+                                                        :apis []
+                                                        :authorizations {}}))
   (fact "apis"
     (fact "none"
       (api-listing ..map.. {}) => (has-apis []))
@@ -456,6 +458,7 @@
                                               :paramType :path
                                               :required true
                                               :type "string"}]
+                                :authorizations {}
                                 :summary ..summary..
                                 :type 'Pet}]
                   :path "/pets/{id}"}
@@ -468,6 +471,7 @@
                                               :paramType :query
                                               :required true
                                               :type "string"}]
+                                :authorizations {}
                                 :summary ..summary2..
                                 :type "array"
                                 :items {:$ref 'Pet}}]
@@ -498,6 +502,7 @@
                                   :notes ""
                                   :parameters []
                                   :responseMessages []
+                                  :authorizations {}
                                   :summary ""
                                   :type "string"}]
                     :path "/primitive"}
@@ -506,6 +511,7 @@
                                   :notes ""
                                   :parameters []
                                   :responseMessages []
+                                  :authorizations {}
                                   :summary ""
                                   :type "array"
                                   :items {:type "string"}}]


### PR DESCRIPTION
This PR is a part of a changeset (I'll send PRs to `ring-swagger-ui` and `fnhouse-swagger` in a minute) that is required to support OAuth2-protected API. 

OAuth2 is supported in Swagger-UI and Swagger Spec, but `ring-swagger` doesn't emit auth specs now. They should be emitted in three ways:
- `authorizations` field in API spec that contains endpoint specification as well as auth scopes specification. This one can be provided in `parameters` argument to `ring.swagger.core/api-listing`;
- `authorizations` field on particular endpoint that specifies which scopes are required to access the endpoint. This one is passed through `metadata` map of particular route;
- finally, Swagger UI needs OAuth2 parameters (client id, realm and app name), so those are accepted as parameters of `ring.swagger.ui/swagger-ui`.
