### PR TITLE
Checkable headers schema

### DIFF
--- a/src/ring/swagger/swagger2.clj
+++ b/src/ring/swagger/swagger2.clj
@@ -173,8 +173,13 @@
                   (if-let [json-schema (->json schema)]
                     json-schema
                     (transform schema)))
-        responses (for-map [[k v] responses]
-                    k (update-in v [:schema] convert))]
+        responses (for-map [[k v] responses
+                            :let [{:keys [schema headers description]} v]]
+                    k (merge v
+                             (when schema
+                               {:schema (convert schema)})
+                             (when headers
+                               {:headers (properties headers)})))]
     (if-not (empty? responses)
       responses
       {:default {:description "" :schema s/Any}})))

--- a/src/ring/swagger/swagger2_schema.clj
+++ b/src/ring/swagger/swagger2_schema.clj
@@ -46,12 +46,10 @@
 ; TODO
 (s/defschema Example s/Any)
 
-; TODO
-(s/defschema Schema s/Any)
 
 (s/defschema Response {:description s/Str
                        (s/optional-key :schema) Schema
-                       (s/optional-key :headers) [SerializableType]
+                       (s/optional-key :headers) Schema
                        (s/optional-key :examples) Example})
 
 (s/defschema Responses (merge

--- a/test/ring/swagger/swagger2_test.clj
+++ b/test/ring/swagger/swagger2_test.clj
@@ -91,7 +91,8 @@
                                                    :responses  {200      {:description "ok"
                                                                           :schema      {:sum Long}}
                                                                 :default {:description "error"
-                                                                          :schema      {:code Long}}}}
+                                                                          :schema      {:code Long}
+                                                                          :headers     {:location String}}}}
                                             :put  {:parameters {:body     [Pet]
                                                                 :query    (merge Anything {:x Long :y Long})
                                                                 :path     Nothing
@@ -107,4 +108,3 @@
 
     (fact "produces valid swagger json"
       (validate-swagger-json swagger) => nil)))
-


### PR DESCRIPTION
The schema is converted to https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#headers-object-

I think `:headers` should default to `schema/Any` but I had some problems with `swagger2_unit_test` so I left it nil for now.