### PR TITLE
Make response description optional

### DIFF
--- a/src/ring/swagger/swagger2.clj
+++ b/src/ring/swagger/swagger2.clj
@@ -1,7 +1,6 @@
 (ns ring.swagger.swagger2
   (:require [clojure.string :as str]
             [clojure.walk :as walk]
-            [ring.util.response :refer :all]
             [ring.swagger.impl :refer :all]
             [schema.core :as s]
             [plumbing.core :refer :all :exclude [update]]
@@ -165,6 +164,11 @@
                           :required (s/required-key? k)}
                          (->json v)))))
 
+(defn- ->description [status]
+  ;; should use ring.util.http-response status description
+  ;; e.g. (:description (get statuses status))
+  (str status))
+
 (defn convert-parameters [parameters]
   (into [] (mapcat extract-parameter parameters)))
 
@@ -178,6 +182,7 @@
                     k (-> v
                           (cond-> schema (update-in [:schema] convert))
                           (cond-> headers (update-in [:headers] properties))
+                          (assoc :description (or description  (->description k) ""))
                           remove-empty-keys))]
     (if-not (empty? responses)
       responses

--- a/src/ring/swagger/swagger2_schema.clj
+++ b/src/ring/swagger/swagger2_schema.clj
@@ -46,7 +46,7 @@
 ; TODO
 (s/defschema Example s/Any)
 
-(s/defschema Response {:description s/Str
+(s/defschema Response {(s/optional-key :description) s/Str
                        (s/optional-key :schema) Schema
                        (s/optional-key :headers) Schema
                        (s/optional-key :examples) Example})

--- a/test/ring/swagger/swagger2_test.clj
+++ b/test/ring/swagger/swagger2_test.clj
@@ -108,10 +108,8 @@
                                                                 :path     Nothing
                                                                 :header   Anything
                                                                 :formData Anything}
-                                                   :responses  {200      {:description "ok"
-                                                                          :schema      {:sum Long}}
-                                                                :default {:description "error"
-                                                                          :schema      {:code Long}
+                                                   :responses  {200      {:schema      {:sum Long}}
+                                                                :default {:schema      {:code Long}
                                                                           :headers     {:location String}}}}
                                             :put  {:parameters {:body     [Pet]
                                                                 :query    (merge Anything {:x Long :y Long})


### PR DESCRIPTION
The idea would be to use the standard description for the given status (e.g. "The server has received the request headers and the client should proceed to send the request body.") but that requires some refactoring in `ring.util.http-response`.

What do you guys think? I would still merge it as-is so we don't force users to provide a `:description` key.