### PR TITLE
Support schema.core.One

### DIFF
--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -104,6 +104,7 @@
 (defmethod json-type schema.core.Recursive      [e] (->json (:derefable e)))
 (defmethod json-type schema.core.EqSchema       [e] (->json (class (:v e))))
 (defmethod json-type schema.core.NamedSchema    [e] (->json (:schema e)))
+(defmethod json-type schema.core.One            [e] (->json (:schema e)))
 (defmethod json-type schema.core.AnythingSchema [_] nil)
 
 (defmethod json-type :default [e]


### PR DESCRIPTION
This is a default schema.core construct that was missing. This is useful to declare sequences of values with a minimum cardinality of one. For example ```[(schema.core/one String "...") String]``` declares a sequence of strings with at least one value.