### PR TITLE
Support for primitive arrays (fixes #55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ existing JSON Schema custom implementations you'll need to convert those.
    generating new names for all the requests.
    
 - Fixes [54](https://github.com/metosin/ring-swagger/issues/54): `:paths` order is now preserved
-  - use `flatland.ordered.map/ordered-map` in the client side to keep the order.
+
+- Fixes [55](https://github.com/metosin/ring-swagger/issues/55): arrays of primitives now supported as 
+  top-level items
 
 - updated dependencies:
 

--- a/test/ring/swagger/swagger2_test.clj
+++ b/test/ring/swagger/swagger2_test.clj
@@ -282,6 +282,44 @@
                 {:type "object"
                  :additionalProperties {:$ref "#/definitions/Kukka"}}))))
 
+(fact "body param is array of primitives"
+  (let [swagger {:paths {"/array" {:post {:parameters {:body [s/Str]}}}}}
+        spec (swagger-json swagger)]
+    (validate swagger) => nil
+
+    (let [param (first (get-in spec [:paths "/array" :post :parameters]))]
+      (some? param) => true
+      (get-in param [:schema :type]) => "array"
+      (get-in param [:schema :items :type]) => "string")))
+
+(fact :hmm "response is array of primitives"
+  (let [swagger {:paths {"/array" {:get {:responses {200 {:schema [Long]}}}}}}
+        spec (swagger-json swagger)]
+    (validate swagger) => nil
+
+    (let [param (get-in spec [:paths "/array" :get :responses 200])]
+      (some? param) => true
+      (get-in param [:schema :type]) => "array"
+      (get-in param [:schema :items :type]) => "integer")))
+
+(fact "body param is array of primitives with schema definition"
+  (let [MyArrayOfInt (s/schema-with-name [s/Str] 'MyArrayOfInt)
+        swagger {:paths {"/array" {:post {:parameters {:body MyArrayOfInt}}}}}
+        spec (swagger-json swagger)]
+    (validate swagger) => nil
+
+    (let [param (first (get-in spec [:paths "/array" :post :parameters]))]
+      (some? param) => true
+      (get-in param [:schema :type]) => "array"
+      (get-in param [:schema :items :type]) => "string")
+
+    ;; TODO: this should pass
+    ;spec => (has-definition
+    ;          'MyArrayOfInt
+    ;          {:type "array"
+    ;           :items {:type "string"}})
+    ))
+
 (fact "tags"
   (let [swagger {:tags [{:name "pet"
                          :description "Everything about your Pets"


### PR DESCRIPTION
Ok, after much scratching my head I've come up with this fix for #55. It works for what I need it to do, which is generating schemas for lists of primitives as body or response parameters.

One thing it doesn't currently do is refer back to schema names that define lists of primitives; instead it will copy them into the parameter definition. I left some [commented code in a test](https://github.com/metosin/ring-swagger/compare/master...timgilbert:arrays-of-primitive-at-top-level?expand=1#diff-e87269f1fc44181b7ec8e9da5c561595R316) that demonstrates this. I may spend a bit of time trying to fix that, but the rest of the PR seems useful enough that I'm submitting it as-is for now. Please let me know if there's anything you'd like me to change.