### PR TITLE
Better Maybe support for core types

### DIFF
--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -134,7 +134,11 @@
   (json-property [e _] (merge (->json (class (first (:vs e)))) {:enum (seq (:vs e))}))
 
   schema.core.Maybe
-  (json-property [e _] (->json (:schema e)))
+  (json-property [e _] (let [schema (->json (:schema e))
+                             type   (:type schema)]
+                         (if type
+                           (assoc schema :type [type "null"])
+                           schema)))
 
   schema.core.Both
   (json-property [e _] (->json (first (:schemas e))))

--- a/test/ring/swagger/json_schema_test.clj
+++ b/test/ring/swagger/json_schema_test.clj
@@ -49,8 +49,13 @@
       (->json (s/enum :kikka :kakka)) => {:type "string" :enum [:kikka :kakka]}
       (->json (s/enum 1 2 3))         => {:type "integer" :format "int64" :enum (seq #{1 2 3})})
 
-    (fact "s/maybe -> type of internal schema"
-      (->json (s/maybe Long))         => (->json Long))
+    (fact "s/maybe[type] -> core type + null"
+      (->json (s/maybe Long))         => (let [json (->json Long)
+                                               type (:type json)]
+                                           (assoc json :type [type "null"])))
+
+    (fact "s/maybe[model] -> type of internal schema"
+      (->json (s/maybe Model))         => (->json Model))
 
     (fact "s/both -> type of the first element"
       (->json (s/both Long String))   => (->json Long))


### PR DESCRIPTION
Use `"type":["int", "null"]` in JSON schema to indicate a field that can be nullable.