### PR TITLE
allow dates to be created from numbers (timestamps)

### DIFF
--- a/test/ring/swagger/coerce_test.clj
+++ b/test/ring/swagger/coerce_test.clj
@@ -8,16 +8,22 @@
 (fact "json coercions"
   (let [c (coercer :json)]
 
-    (fact "Date with and without millis"
+    (fact "Date with / without millis and and from long / string-long"
       ((c Date) "2014-02-18T18:25:37.456Z") => (partial instance? Date)
-      ((c Date) "2014-02-18T18:25:37Z") => (partial instance? Date))
+      ((c Date) "2014-02-18T18:25:37Z") => (partial instance? Date)
+      ((c Date) "1432439999999") => (partial instance? Date)
+      ((c Date) 1432439999999) => (partial instance? Date))
 
-    (fact "DateTime with and without millis"
+    (fact "DateTime with / without millis and from long / string-long"
       ((c DateTime) "2014-02-18T18:25:37.456Z") => (partial instance? DateTime)
-      ((c DateTime) "2014-02-18T18:25:37Z") => (partial instance? DateTime))
+      ((c DateTime) "2014-02-18T18:25:37Z") => (partial instance? DateTime)
+      ((c DateTime) "1432439999999") => (partial instance? DateTime)
+      ((c DateTime) 1432439999999) => (partial instance? DateTime))
 
-    (fact "LocalDate"
-      ((c LocalDate) "2014-02-19") => (partial instance? LocalDate))
+    (fact "LocalDate from string, long / string-long"
+      ((c LocalDate) "2014-02-19") => (partial instance? LocalDate)
+      ((c LocalDate) "1432439999999") => (partial instance? LocalDate)
+      ((c LocalDate) 1432439999999) => (partial instance? LocalDate))
 
     (fact "UUID"
       ((c UUID) "77e70512-1337-dead-beef-0123456789ab") => (partial instance? UUID))))


### PR DESCRIPTION
I'm using ring-swagger in an API and the client-side is using timestamps. Unfortunately, using `org.joda.time.DateTime` in the schema was resulting in an error; the coercion didn't know what to do with a string timestamp such as "1432439999999".

I added the necessary code and tests.

However, with these new additions, `lein midje` fails in another section:

```
FAIL "All types can be read from json - coerce! makes models match" at (schema_test.clj:68)
    Expected: {:a true, :b 2.2, :c 16, :d "kikka", :e {:f [:kikka :kikka :kukka], :g #{"kakka" "kikka"}, :h #{:kikka}, :i #inst "2015-08-14T19:50:26.255-00:00", :j #<DateTime 2015-08-14T19:50:26.255Z>, :k #<LocalDate 2015-08-14>, :l nil, :m 1, :n {:alive true}, :o [{:p #{{:q "abba"}}}], :u #uuid "77e70512-1337-dead-beef-0123456789ab", :v "a[6-9]", :w "a9"}}
      Actual: {:a true, :b 2.2, :c 16, :d "kikka", :e {:f [:kikka :kikka :kukka], :g #{"kakka" "kikka"}, :h #{:kikka}, :i #inst "2015-08-14T19:50:26.255-00:00", :j #<DateTime 2015-08-14T15:50:26.255-04:00>, :k #<LocalDate 2015-08-14>, :l nil, :m 1, :n {:alive true}, :o [{:p #{{:q "abba"}}}], :u #uuid "77e70512-1337-dead-beef-0123456789ab", :v "a[6-9]", :w "a9"}}
       Diffs: in [:e :j] expected #<DateTime 2015-08-14T19:50:26.255Z>, was #<DateTime 2015-08-14T15:50:26.255-04:00>
FAILURE: 1 check failed.  (But 328 succeeded.)
```

I'm totally unfamiliar this section of the code (and midje in general), so I'm still pushing this in the hope that this is a trivial error.