### PR TITLE
Cleanup for 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,15 @@
 - **BREAKING**: `ring.swagger.json-schema/json-type` multimethod is removed
   - will cause compile-time errors for those who have client-side custom extensions
   - new way of doing the Schema -> Swagger Schema mappings:
-    - Classes via `ring.swagger.json-schema/to-json-property` multimethod, taking both the class and swagger options
+    - Classes via `ring.swagger.json-schema/convert-class` multimethod, taking both the class and swagger options
     - Objects (e.g. records) via `ring.swagger.json-schema/JsonSchema` protocol.
 
-- **BREAKING**: `ring.swagger.json-schema/->json` signature has changed, instead of kwargs it now takes a options map.
+- lot's of internal cleanup in `ring.swagger.json-schema`:
+  - `->json` is now `->swagger` and takes options map instead of kwargs.
   - removed option `:top` (required only for Swagger 1.2)
   - new option `:in` denote the parameter type (`:query`, `:header`, `:path`, `:formData` or `:body`)
      - responses don't have `:in`.
-  
+
 ### New features
 
 - Support for collections in query and form parameters (even with single parameter):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 - **BREAKING**: Swagger 1.2 is no more supported.
 
-- **BREAKING**: Json Schema conversion for objects (e.g. records) is now extendable using a protocol instead of a
-multimethod. Check [json-schema.clj](./src/ring/swagger/json_schema.clj) for the new implementation. If you have
-existing JSON Schema custom implementations you'll need to convert those.
+- **BREAKING**: `ring.swagger.json-schema/json-type` multimethod is removed
+  - will cause compile-time errors for those who have client-side custom extensions
+  - new way of doing the Schema -> Swagger Schema mappings:
+    - Classes via `ring.swagger.json-schema/to-json-property` multimethod, taking both the class and swagger options
+    - Objects (e.g. records) via `ring.swagger.json-schema/JsonSchema` protocol.
 
 - **BREAKING**: `ring.swagger.json-schema/->json` signature has changed, instead of kwargs it now takes a options map.
   - removed option `:top` (required only for Swagger 1.2)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@
 - [pedastal-swagger](https://github.com/frankiesardo/pedestal-swagger) for Pedastal
 - [yada](https://github.com/juxt/yada)
 
-Route definitions are expected as a clojure Map defined by the Schema [Contract](https://github.com/metosin/ring-swagger/blob/master/src/ring/swagger/swagger2_schema.clj). The Schema allows mostly any extra keys as ring-swagger tries not to be on your way - one can pass any valid Swagger spec data in.
+Route definitions are expected as a clojure Map defined by the Schema [Contract](https://github.com/metosin/ring-swagger/blob/master/src/ring/swagger/swagger2_schema.clj).
+The Schema allows mostly any extra keys as ring-swagger tries not to be on your way - one can pass any 
+valid Swagger spec data in.
 
 ### Simplest possible example
 
@@ -146,7 +148,8 @@ One can pass extra options-map as a third parameter to `swagger-json`. The follo
                                     Possible values: multi, ssv, csv, tsv, pipes."
 ```
 
-For example, to get default response descriptions from the [HTTP Spec](http://en.wikipedia.org/wiki/List_of_HTTP_status_codes), you can do the following:
+For example, to get default response descriptions from the [HTTP Spec](http://en.wikipedia.org/wiki/List_of_HTTP_status_codes),
+you can do the following:
 
 ```clojure
 (require '[ring.util.http-status :as status])
@@ -169,7 +172,8 @@ For example, to get default response descriptions from the [HTTP Spec](http://en
 
 ## Validating the Swagger Spec
 
-The generated full spec can be validated against the [Swagger JSON Schema](https://raw.githubusercontent.com/reverb/swagger-spec/master/schemas/v2.0/schema.json) via tools like [scjsv](https://github.com/metosin/scjsv).
+The generated full spec can be validated against the [Swagger JSON Schema](https://raw.githubusercontent.com/reverb/swagger-spec/master/schemas/v2.0/schema.json)
+via tools like [scjsv](https://github.com/metosin/scjsv).
 
 ```clojure
 (require '[scjsv.core :as scjsv])
@@ -194,10 +198,8 @@ For more information about creating your own adapter, see [Collecting API Docume
 
 There are the following utility functions for transforming the spec (on the client side):
 
-### `ring.swagger.swagger2/transform-operations`
-
-Transforms the operations under the :paths of a ring-swagger spec by applying `(f operation)` to all operations.
-If the function returns nil, the given operation is removed.
+`ring.swagger.swagger2/transform-operations` - transforms the operations under the :paths of a ring-swagger spec
+by applying `(f operation)` to all operations. If the function returns nil, the given operation is removed.
 
 As an example, one can filter away all operations with `:x-no-doc` set to `true`:
 
@@ -213,11 +215,11 @@ As an example, one can filter away all operations with `:x-no-doc` set to `true`
 
 ## Web Schemas
 
-[Prismatic Schema](https://github.com/Prismatic/schema) is used for describing both the input & output schemas for routes.
+[Prismatic Schema](https://github.com/Prismatic/schema) is used to describe both the input & output schemas for routes.
 
-As Swagger 2.0 Spec Schema is a pragmatic and deterministic subset of JSON Schema, so not all Clojure Schema elements can be used.
+As Swagger 2.0 Spec Schema is a deterministic subset of JSON Schema, so not all Clojure Schema elements can be used.
 
-### Schema to Swagger JSON Schema transformation
+### Schema to Swagger JSON Schema conversion
 
 There are two possible methods to do this:
 
@@ -230,7 +232,7 @@ of the schema (`nil`, `:query`, `:header`, `:path`, `:formData` and `:body`).
 To support truly symmetric web schemas, one needs also to ensure both JSON Serialization and
 deserialization/coercion from JSON.
 
-#### Class-based dispatch
+### Class-based dispatch
 
 ```clojure
 (require '[ring.swagger.json-schema :as json-schema])
@@ -292,39 +294,47 @@ One can also use the options to create more accurate specs (via the `:in` option
 - Vectors, Sets and Maps can be used as containers
 - Maps are presented as Complex Types and References. Model references are resolved automatically.
   - Nested maps are transformed automatically into flat maps with generated child references
-    - Nested maps can be within valid containers (as only element - heterogeneous schema sequences not supported by the spec)
+  - Maps can be within valid containers (as only element - heterogeneous schema sequences not supported by the spec)
 
 ### Missing Schema elements
 
-If Ring-swagger can't transform the Schemas into JSON Schemas, by default a `IllegalArgumentException` will be thrown. Binding `ring.swagger.json-schema/*ignore-missing-mappings*` to true, one can ignore the errors (missing schema elements will be ignored from the generated JSON Schema).
+If Ring-swagger can't transform the Schemas into JSON Schemas, by default a `IllegalArgumentException` will be thrown.
+Setting the `:ignore-missing-mappings?` to `true` causes the errors to be ignored - missing schema elements will be
+ignored from the generated Swagger schema.
 
 ### Body and Response model names
 
-Standard Prismatic Schema names are used. Nested schemas are traversed and all found sub-schemas are named automatically - so that they can be referenced in the generated Swagger spec.
+Standard Prismatic Schema names are used. Nested schemas are traversed and all found sub-schemas are named
+automatically - so that they can be referenced in the generated Swagger spec.
 
-Swagger 2.0 squashes all api models into a single global namespace, so schema name collisions can happen. When this happens, the function defined by `:handle-duplicate-schemas-fn` option is called to resolve the collision. By default, the collisions are ignored.
+Swagger 2.0 squashes all api models into a single global namespace, so schema name collisions can happen.
+When this happens, the function defined by `:handle-duplicate-schemas-fn` option is called to resolve the collision.
+By default, the collisions are ignored.
 
-One accidental reason for schema name collisions is the use of normal `clojure.core` functions to create transformed copies of the schemas. The normal core functions retain the original schema meta-data and by so the schema name.
+One accidental reason for schema name collisions is the use of normal `clojure.core` functions to create transformed
+copies of the schemas. The normal core functions retain the original schema meta-data and by so the schema name.
 
 ```clojure
 (s/defschema User {:id s/Str, :name s/Str})
 (def NewUser (dissoc User :id)) ; dissoc does not remove the schema meta-data
 
 (meta User)
-; {:name Kikka}
+; {:name User :ns user}
+
 
 (meta NewUser)
-; {:name Kikka} <- fail!
+; {:name User :ns user} <--- fail, now there are two User-schemas around.
 ```
 
 There are better schema transformers functions available at [schema-tools](https://github.com/metosin/schema-tools).
+It's an implicit dependency of ring-swagger.
 
 ### Extra Schema elements supported by `ring.swagger.json-schema-dirty`
 
 Some Schema elements are impossible to accurately describe within boundaries of JSON-Schema or Swagger spec.
 You can require `ring.swagger.json-schema-dirty` namespace to get JSON Schema dispatching for the following:
 
-Be warned that Swagger-UI might not display these correctly and the code generated by swagger-codegen will be inaccurate.
+**WARNING** Swagger-UI might not display these correctly and the code generated by swagger-codegen will be inaccurate.
 
 | Clojure | JSON Schema | Sample  |
 | --------|-------|:------------:|
@@ -340,13 +350,18 @@ These schemas should work, just need the mappings (feel free to contribute!):
 
 ### Schema coercion
 
-Ring-swagger uses [Schema coercions](http://blog.getprismatic.com/blog/2014/1/4/schema-020-back-with-clojurescript-data-coercion) for transforming the input data into vanilla Clojure and back.
+Ring-swagger uses [Schema coercions](http://blog.getprismatic.com/blog/2014/1/4/schema-020-back-with-clojurescript-data-coercion)
+for transforming the input data into vanilla Clojure and back.
 
-There are two coercers in `ring.swagger.coerce`, the `json-schema-coercion-matcher` and `query-schema-coercion-matcher`. These are enchanced versions of the orginal Schema coercers, adding support for all the supported Schema elements, including Dates & Regexps.
+There are two coercers in `ring.swagger.coerce`, the `json-schema-coercion-matcher` and `query-schema-coercion-matcher`.
+These are enchanced versions of the original Schema coercers, adding support for all the supported Schema elements,
+including Dates & Regexps.
 
 #### Coerce!
 
-Ring-swagger provides a convenience function for coercion, `ring.swagger.schema/coerce!`. It returns either a valid coerced value of slingshots an Map with type `:ring.swagger.schema/validation`. One can catch these exceptions via `ring.swagger.middleware/wrap-validation-errors` and return a JSON-friendly map of the contents.
+Ring-swagger provides a convenience function for coercion, `ring.swagger.schema/coerce!`. It returns either a valid
+coerced value of slingshots an Map with type `:ring.swagger.schema/validation`. One can catch these exceptions via
+`ring.swagger.middleware/wrap-validation-errors` and return a JSON-friendly map of the contents.
 
 ```clojure
 (require '[schema.core :as s])

--- a/src/ring/swagger/common.clj
+++ b/src/ring/swagger/common.clj
@@ -68,3 +68,9 @@
 
       :else
       (last values))))
+
+(defn predicate?
+  "Tests whether the input is an instance of a predicate"
+  [x] (= (class x) schema.core.Predicate))
+
+(def not-predicate? (complement predicate?))

--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -33,10 +33,10 @@
 ;; Describe Java and Clojure classes and Schemas as Json schema
 ;;
 
-(defmulti to-json-property (fn [c options] c))
+(defmulti convert-class (fn [c options] c))
 
 (defprotocol JsonSchema
-  (json-property [this options]))
+  (convert [this options]))
 
 (defn assoc-collection-format
   "Add collectionFormat to the JSON Schema if the parameter type
@@ -56,20 +56,20 @@
   (throw (IllegalArgumentException. (str "don't know how to create json-type of: " e))))
 
 ;; Classes
-(defmethod to-json-property java.lang.Integer       [_ _] {:type "integer" :format "int32"})
-(defmethod to-json-property java.lang.Long          [_ _] {:type "integer" :format "int64"})
-(defmethod to-json-property java.lang.Double        [_ _] {:type "number" :format "double"})
-(defmethod to-json-property java.lang.Number        [_ _] {:type "number" :format "double"})
-(defmethod to-json-property java.lang.String        [_ _] {:type "string"})
-(defmethod to-json-property java.lang.Boolean       [_ _] {:type "boolean"})
-(defmethod to-json-property clojure.lang.Keyword    [_ _] {:type "string"})
-(defmethod to-json-property java.util.UUID          [_ _] {:type "string" :format "uuid"})
-(defmethod to-json-property java.util.Date          [_ _] {:type "string" :format "date-time"})
-(defmethod to-json-property org.joda.time.DateTime  [_ _] {:type "string" :format "date-time"})
-(defmethod to-json-property org.joda.time.LocalDate [_ _] {:type "string" :format "date"})
-(defmethod to-json-property java.util.regex.Pattern [_ _] {:type "string" :format "regex"})
+(defmethod convert-class java.lang.Integer       [_ _] {:type "integer" :format "int32"})
+(defmethod convert-class java.lang.Long          [_ _] {:type "integer" :format "int64"})
+(defmethod convert-class java.lang.Double        [_ _] {:type "number" :format "double"})
+(defmethod convert-class java.lang.Number        [_ _] {:type "number" :format "double"})
+(defmethod convert-class java.lang.String        [_ _] {:type "string"})
+(defmethod convert-class java.lang.Boolean       [_ _] {:type "boolean"})
+(defmethod convert-class clojure.lang.Keyword    [_ _] {:type "string"})
+(defmethod convert-class java.util.UUID          [_ _] {:type "string" :format "uuid"})
+(defmethod convert-class java.util.Date          [_ _] {:type "string" :format "date-time"})
+(defmethod convert-class org.joda.time.DateTime  [_ _] {:type "string" :format "date-time"})
+(defmethod convert-class org.joda.time.LocalDate [_ _] {:type "string" :format "date"})
+(defmethod convert-class java.util.regex.Pattern [_ _] {:type "string" :format "regex"})
 
-(defmethod to-json-property :default [e _]
+(defmethod convert-class :default [e _]
   (if-not *ignore-missing-mappings*
     (not-supported! e)))
 
@@ -85,93 +85,93 @@
     (and (not *ignore-missing-mappings*)
          (not-supported! e))))
 
-(defn ->json
-  ([x] (->json x {}))
+(defn ->swagger
+  ([x] (->swagger x {}))
   ([x options]
-   (merge-meta (json-property x options) x options)))
+   (merge-meta (convert x options) x options)))
 
 (defn- coll-schema [e options]
   (-> {:type "array"
-       :items (->json (first e) (assoc options ::no-meta true))}
+       :items (->swagger (first e) (assoc options ::no-meta true))}
       (assoc-collection-format options)))
 
 (extend-protocol JsonSchema
 
   Object
-  (json-property [e _]
+  (convert [e _]
     (not-supported! e))
 
   Class
-  (json-property [e options]
-    (to-json-property e options))
+  (convert [e options]
+    (convert-class e options))
 
   nil
-  (json-property [_ _]
+  (convert [_ _]
     ; TODO: should be nil?
     {:type "void"})
 
   schema.core.Predicate
-  (json-property [e _]
-    (some-> e :p? predicate-to-class ->json))
+  (convert [e _]
+    (some-> e :p? predicate-to-class ->swagger))
 
   schema.core.EnumSchema
-  (json-property [e _]
-    (merge (->json (class (first (:vs e)))) {:enum (seq (:vs e))}))
+  (convert [e _]
+    (merge (->swagger (class (first (:vs e)))) {:enum (seq (:vs e))}))
 
   schema.core.Maybe
-  (json-property [e {:keys [in]}]
-    (let [schema (->json (:schema e))]
+  (convert [e {:keys [in]}]
+    (let [schema (->swagger (:schema e))]
       (if (#{:query :formData} in)
         (assoc schema :allowEmptyValue true)
         schema)))
 
   schema.core.Both
-  (json-property [e _]
-    (->json (first (:schemas e))))
+  (convert [e _]
+    (->swagger (first (:schemas e))))
 
   schema.core.Either
-  (json-property [e _]
-    (->json (first (:schemas e))))
+  (convert [e _]
+    (->swagger (first (:schemas e))))
 
   schema.core.Recursive
-  (json-property [e _]
-    (->json (:derefable e)))
+  (convert [e _]
+    (->swagger (:derefable e)))
 
   schema.core.EqSchema
-  (json-property [e _]
-    (->json (class (:v e))))
+  (convert [e _]
+    (->swagger (class (:v e))))
 
   schema.core.NamedSchema
-  (json-property [e _]
-    (->json (:schema e)))
+  (convert [e _]
+    (->swagger (:schema e)))
 
   schema.core.One
-  (json-property [e _]
-    (->json (:schema e)))
+  (convert [e _]
+    (->swagger (:schema e)))
 
   schema.core.AnythingSchema
-  (json-property [_ _] nil)
+  (convert [_ _] nil)
 
   java.util.regex.Pattern
-  (json-property [e _]
+  (convert [e _]
     {:type "string" :pattern (str e)})
 
   ;; Collections
 
   clojure.lang.Sequential
-  (json-property [e options]
+  (convert [e options]
     (coll-schema e options))
 
   clojure.lang.IPersistentSet
-  (json-property [e options]
+  (convert [e options]
     (assoc (coll-schema e options) :uniqueItems true))
 
   clojure.lang.IPersistentMap
-  (json-property [e _]
+  (convert [e _]
     (reference e))
 
   clojure.lang.Var
-  (json-property [e _]
+  (convert [e _]
     (reference e)))
 
 ;;
@@ -184,7 +184,7 @@
 (def not-predicate? (complement predicate?))
 
 (defn try->json [v k]
-  (try (->json v)
+  (try (->swagger v)
        (catch Exception e
          (throw
            (IllegalArgumentException.

--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -96,21 +96,27 @@
       (assoc-collection-format options)))
 
 (extend-protocol JsonSchema
+
   Object
-  (json-property [e _] (not-supported! e))
+  (json-property [e _]
+    (not-supported! e))
 
   Class
   (json-property [e options]
     (to-json-property e options))
 
   nil
-  (json-property [_ _] {:type "void"})
+  (json-property [_ _]
+    ; TODO: should be nil?
+    {:type "void"})
 
   schema.core.Predicate
-  (json-property [e _] (some-> e :p? predicate-to-class ->json))
+  (json-property [e _]
+    (some-> e :p? predicate-to-class ->json))
 
   schema.core.EnumSchema
-  (json-property [e _] (merge (->json (class (first (:vs e)))) {:enum (seq (:vs e))}))
+  (json-property [e _]
+    (merge (->json (class (first (:vs e)))) {:enum (seq (:vs e))}))
 
   schema.core.Maybe
   (json-property [e {:keys [in]}]
@@ -120,41 +126,53 @@
         schema)))
 
   schema.core.Both
-  (json-property [e _] (->json (first (:schemas e))))
+  (json-property [e _]
+    (->json (first (:schemas e))))
 
   schema.core.Either
-  (json-property [e _] (->json (first (:schemas e))))
+  (json-property [e _]
+    (->json (first (:schemas e))))
 
   schema.core.Recursive
-  (json-property [e _] (->json (:derefable e)))
+  (json-property [e _]
+    (->json (:derefable e)))
 
   schema.core.EqSchema
-  (json-property [e _] (->json (class (:v e))))
+  (json-property [e _]
+    (->json (class (:v e))))
 
   schema.core.NamedSchema
-  (json-property [e _] (->json (:schema e)))
+  (json-property [e _]
+    (->json (:schema e)))
 
   schema.core.One
-  (json-property [e _] (->json (:schema e)))
+  (json-property [e _]
+    (->json (:schema e)))
 
   schema.core.AnythingSchema
   (json-property [_ _] nil)
 
   java.util.regex.Pattern
-  (json-property [e _] {:type "string" :pattern (str e)})
+  (json-property [e _]
+    {:type "string" :pattern (str e)})
 
   ;; Collections
+
   clojure.lang.Sequential
-  (json-property [e options] (coll-schema e options))
+  (json-property [e options]
+    (coll-schema e options))
 
   clojure.lang.IPersistentSet
-  (json-property [e options] (assoc (coll-schema e options) :uniqueItems true))
+  (json-property [e options]
+    (assoc (coll-schema e options) :uniqueItems true))
 
   clojure.lang.IPersistentMap
-  (json-property [e _] (reference e))
+  (json-property [e _]
+    (reference e))
 
   clojure.lang.Var
-  (json-property [e _] (reference e)))
+  (json-property [e _]
+    (reference e)))
 
 ;;
 ;; Schema -> Json Schema

--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -3,12 +3,12 @@
             [ring.swagger.common :as c ]
             [flatland.ordered.map :refer :all]))
 
+; TODO: remove this in favor of passing it as options
 (def ^:dynamic *ignore-missing-mappings* false)
 
 (defn json-schema-meta
   "Select interesting keys from meta-data of schema."
-  [schema]
-  (:json-schema (meta schema)))
+  [schema] (:json-schema (meta schema)))
 
 ;;
 ;; Schema implementation which is used wrap stuff which doesn't support meta-data

--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -1,6 +1,6 @@
 (ns ring.swagger.json-schema
   (:require [schema.core :as s]
-            [ring.swagger.common :as c ]
+            [ring.swagger.common :as c]
             [flatland.ordered.map :refer :all]))
 
 ; TODO: remove this in favor of passing it as options
@@ -90,6 +90,15 @@
   ([x options]
    (merge-meta (convert x options) x options)))
 
+(defn- try->swagger [v k]
+  (try (->swagger v)
+       (catch Exception e
+         (throw
+           (IllegalArgumentException.
+             (str "error converting to swagger schema [" k " "
+                  (try (s/explain v) (catch Exception _ v)) "]") e)))))
+
+
 (defn- coll-schema [e options]
   (-> {:type "array"
        :items (->swagger (first e) (assoc options ::no-meta true))}
@@ -174,16 +183,8 @@
     (reference e)))
 
 ;;
-;; Schema -> Json Schema
+;; Schema to Swagger Schmea definitions
 ;;
-
-(defn try->swagger [v k]
-  (try (->swagger v)
-       (catch Exception e
-         (throw
-           (IllegalArgumentException.
-             (str "error converting to json schema [" k " "
-                  (try (s/explain v) (catch Exception _ v)) "]") e)))))
 
 (defn properties
   "Take a map schema and turn them into json-schema properties.

--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -33,14 +33,14 @@
 ;; Describe Java and Clojure classes and Schemas as Json schema
 ;;
 
-(defmulti json-type identity)
+(defmulti to-json-property (fn [c options] c))
 
 (defprotocol JsonSchema
   (json-property [this options]))
 
 (defn ->json-schema [x options]
   (if (instance? Class x)
-    (json-type x)
+    (to-json-property x options)
     (json-property x options)))
 
 (defn assoc-collection-format
@@ -66,20 +66,20 @@
    (merge-meta (->json-schema x options) x options)))
 
 ;; Classes
-(defmethod json-type java.lang.Integer       [_] {:type "integer" :format "int32"})
-(defmethod json-type java.lang.Long          [_] {:type "integer" :format "int64"})
-(defmethod json-type java.lang.Double        [_] {:type "number" :format "double"})
-(defmethod json-type java.lang.Number        [_] {:type "number" :format "double"})
-(defmethod json-type java.lang.String        [_] {:type "string"})
-(defmethod json-type java.lang.Boolean       [_] {:type "boolean"})
-(defmethod json-type clojure.lang.Keyword    [_] {:type "string"})
-(defmethod json-type java.util.UUID          [_] {:type "string" :format "uuid"})
-(defmethod json-type java.util.Date          [_] {:type "string" :format "date-time"})
-(defmethod json-type org.joda.time.DateTime  [_] {:type "string" :format "date-time"})
-(defmethod json-type org.joda.time.LocalDate [_] {:type "string" :format "date"})
-(defmethod json-type java.util.regex.Pattern [_] {:type "string" :format "regex"})
+(defmethod to-json-property java.lang.Integer       [_ _] {:type "integer" :format "int32"})
+(defmethod to-json-property java.lang.Long          [_ _] {:type "integer" :format "int64"})
+(defmethod to-json-property java.lang.Double        [_ _] {:type "number" :format "double"})
+(defmethod to-json-property java.lang.Number        [_ _] {:type "number" :format "double"})
+(defmethod to-json-property java.lang.String        [_ _] {:type "string"})
+(defmethod to-json-property java.lang.Boolean       [_ _] {:type "boolean"})
+(defmethod to-json-property clojure.lang.Keyword    [_ _] {:type "string"})
+(defmethod to-json-property java.util.UUID          [_ _] {:type "string" :format "uuid"})
+(defmethod to-json-property java.util.Date          [_ _] {:type "string" :format "date-time"})
+(defmethod to-json-property org.joda.time.DateTime  [_ _] {:type "string" :format "date-time"})
+(defmethod to-json-property org.joda.time.LocalDate [_ _] {:type "string" :format "date"})
+(defmethod to-json-property java.util.regex.Pattern [_ _] {:type "string" :format "regex"})
 
-(defmethod json-type :default [e]
+(defmethod to-json-property :default [e _]
   (if-not *ignore-missing-mappings*
     (not-supported! e)))
 

--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -107,8 +107,7 @@
 
   nil
   (convert [_ _]
-    ; TODO: should be nil?
-    {:type "void"})
+    nil)
 
   schema.core.Predicate
   (convert [e _]

--- a/src/ring/swagger/json_schema_dirty.clj
+++ b/src/ring/swagger/json_schema_dirty.clj
@@ -5,4 +5,5 @@
 
 (extend-protocol JsonSchema
   schema.core.ConditionalSchema
-  (json-property [e _]  {:type "void" :oneOf (mapv (comp ->json second) (:preds-and-schemas e))}))
+  (convert [e _]
+    {:type "void" :oneOf (mapv (comp ->swagger second) (:preds-and-schemas e))}))

--- a/src/ring/swagger/swagger2.clj
+++ b/src/ring/swagger/swagger2.clj
@@ -61,10 +61,10 @@
 
 (defmethod extract-parameter :body [_ model options]
   (if-let [schema (rsc/peek-schema model)]
-    (let [schema-json (jsons/->json model options)]
+    (let [schema-json (jsons/->swagger model options)]
       (vector {:in :body
                :name (name (s/schema-name schema))
-               :description (or (:description (jsons/->json schema options)) "")
+               :description (or (:description (jsons/->swagger schema options)) "")
                :required true
                :schema (dissoc schema-json :description)}))))
 
@@ -73,7 +73,7 @@
     (for [[k v] (-> model value-of rsc/strict-schema)
           :when (s/specific-key? k)
           :let [rk (s/explicit-schema-key k)
-                json-schema (jsons/->json v options)]
+                json-schema (jsons/->swagger v options)]
           :when json-schema]
       (merge
         {:in in
@@ -99,7 +99,7 @@
   (let [responses (for-map [[k v] responses
                             :let [{:keys [schema headers]} v]]
                     k (-> v
-                          (cond-> schema (update-in [:schema] jsons/->json options))
+                          (cond-> schema (update-in [:schema] jsons/->swagger options))
                           (cond-> headers (update-in [:headers] jsons/properties))
                           (update-in [:description] #(or % (default-response-description k options)))
                           remove-empty-keys))]

--- a/src/ring/swagger/upload.clj
+++ b/src/ring/swagger/upload.clj
@@ -1,7 +1,6 @@
 (ns ring.swagger.upload
   (:require [potemkin :refer [import-vars]]
             [ring.middleware.multipart-params]
-            [ring.swagger.json-schema :as js]
             [schema.core :as s]))
 
 (import-vars
@@ -11,17 +10,18 @@
 
 ; Works exactly like map schema but wrapped in record for json-type dispatch
 (defrecord Upload [m]
+
   schema.core.Schema
-  (walker [this]
+  (walker [_]
     (let [sub-walker (s/subschema-walker m)]
       (clojure.core/fn [x]
        (if (schema.utils/error? x)
          x
          (sub-walker x)))))
-  (explain [this] (cons 'file m))
+  (explain [_] (cons 'file m))
 
   ring.swagger.json_schema.JsonSchema
-  (json-property [this _]
+  (convert [_ _]
     {:type "file"}))
 
 (def TempFileUpload

--- a/test/ring/swagger/json_schema_dirty_test.clj
+++ b/test/ring/swagger/json_schema_dirty_test.clj
@@ -6,9 +6,9 @@
 
 (facts "type transformations"
   (fact "schema predicates"
-    (->json (s/conditional (constantly true) Long (constantly false) String))
-    => {:type "void" :oneOf [(->json Long) (->json String)]})
+    (->swagger (s/conditional (constantly true) Long (constantly false) String))
+    => {:type "void" :oneOf [(->swagger Long) (->swagger String)]})
 
   (fact "s/if"
-    (->json (s/if (constantly true) Long String))
-    => {:type "void" :oneOf [(->json Long) (->json String)]}))
+    (->swagger (s/if (constantly true) Long String))
+    => {:type "void" :oneOf [(->swagger Long) (->swagger String)]}))

--- a/test/ring/swagger/json_schema_test.clj
+++ b/test/ring/swagger/json_schema_test.clj
@@ -35,7 +35,7 @@
     (->swagger #{Long})   => {:type "array" :items {:format "int64" :type "integer"} :uniqueItems true})
 
   (facts "nil"
-    (->swagger nil)       => {:type "void"})
+    (->swagger nil)       => nil)
 
   (facts "unknowns"
     (fact "throw exception by default"

--- a/test/ring/swagger/json_schema_test.clj
+++ b/test/ring/swagger/json_schema_test.clj
@@ -12,86 +12,86 @@
 
 (facts "type transformations"
   (facts "java types"
-    (->json Integer)   => {:type "integer" :format "int32"}
-    (->json Long)      => {:type "integer" :format "int64"}
-    (->json Double)    => {:type "number" :format "double"}
-    (->json Number)    => {:type "number" :format "double"}
-    (->json String)    => {:type "string"}
-    (->json Boolean)   => {:type "boolean"}
-    (->json Date)      => {:type "string" :format "date-time"}
-    (->json DateTime)  => {:type "string" :format "date-time"}
-    (->json LocalDate) => {:type "string" :format "date"}
-    (->json Pattern)   => {:type "string" :format "regex"}
-    (->json #"[6-9]")  => {:type "string" :pattern "[6-9]"}
-    (->json UUID)      => {:type "string" :format "uuid"})
+    (->swagger Integer)   => {:type "integer" :format "int32"}
+    (->swagger Long)      => {:type "integer" :format "int64"}
+    (->swagger Double)    => {:type "number" :format "double"}
+    (->swagger Number)    => {:type "number" :format "double"}
+    (->swagger String)    => {:type "string"}
+    (->swagger Boolean)   => {:type "boolean"}
+    (->swagger Date)      => {:type "string" :format "date-time"}
+    (->swagger DateTime)  => {:type "string" :format "date-time"}
+    (->swagger LocalDate) => {:type "string" :format "date"}
+    (->swagger Pattern)   => {:type "string" :format "regex"}
+    (->swagger #"[6-9]")  => {:type "string" :pattern "[6-9]"}
+    (->swagger UUID)      => {:type "string" :format "uuid"})
 
   (fact "schema types"
-    (->json s/Int)     => {:type "integer" :format "int64"}
-    (->json s/Str)     => {:type "string"}
-    (->json s/Num)     => {:type "number" :format "double"})
+    (->swagger s/Int)     => {:type "integer" :format "int64"}
+    (->swagger s/Str)     => {:type "string"}
+    (->swagger s/Num)     => {:type "number" :format "double"})
 
   (fact "containers"
-    (->json [Long])    => {:type "array" :items {:format "int64" :type "integer"}}
-    (->json #{Long})   => {:type "array" :items {:format "int64" :type "integer"} :uniqueItems true})
+    (->swagger [Long])    => {:type "array" :items {:format "int64" :type "integer"}}
+    (->swagger #{Long})   => {:type "array" :items {:format "int64" :type "integer"} :uniqueItems true})
 
   (facts "nil"
-    (->json nil)       => {:type "void"})
+    (->swagger nil)       => {:type "void"})
 
   (facts "unknowns"
     (fact "throw exception by default"
-      (->json java.util.Vector) => (throws IllegalArgumentException))
+      (->swagger java.util.Vector) => (throws IllegalArgumentException))
     (fact "are ignored with *ignore-missing-mappings*"
       (binding [*ignore-missing-mappings* true]
-        (->json java.util.Vector)) => nil))
+        (->swagger java.util.Vector)) => nil))
 
   (facts "models"
-    (->json Model) => {:$ref "#/definitions/Model"}
-    (->json [Model]) => {:items {:$ref "#/definitions/Model"}, :type "array"}
-    (->json #{Model}) => {:items {:$ref "#/definitions/Model"}, :type "array" :uniqueItems true})
+    (->swagger Model) => {:$ref "#/definitions/Model"}
+    (->swagger [Model]) => {:items {:$ref "#/definitions/Model"}, :type "array"}
+    (->swagger #{Model}) => {:items {:$ref "#/definitions/Model"}, :type "array" :uniqueItems true})
 
   (fact "schema predicates"
     (fact "s/enum"
-      (->json (s/enum :kikka :kakka)) => {:type "string" :enum [:kikka :kakka]}
-      (->json (s/enum 1 2 3))         => {:type "integer" :format "int64" :enum (seq #{1 2 3})})
+      (->swagger (s/enum :kikka :kakka)) => {:type "string" :enum [:kikka :kakka]}
+      (->swagger (s/enum 1 2 3))         => {:type "integer" :format "int64" :enum (seq #{1 2 3})})
 
     (fact "s/maybe"
       (fact "uses wrapped value by default"
-        (->json (s/maybe Long)) => (->json Long))
+        (->swagger (s/maybe Long)) => (->swagger Long))
       (fact "adds allowEmptyValue when for query and formData as defined by the spec"
-        (->json (s/maybe Long) {:in :query}) => (assoc (->json Long) :allowEmptyValue true)
-        (->json (s/maybe Long) {:in :formData}) => (assoc (->json Long) :allowEmptyValue true))
+        (->swagger (s/maybe Long) {:in :query}) => (assoc (->swagger Long) :allowEmptyValue true)
+        (->swagger (s/maybe Long) {:in :formData}) => (assoc (->swagger Long) :allowEmptyValue true))
       (fact "uses wrapped value for other parameters"
-        (->json (s/maybe Long) {:in :body}) => (->json Long)
-        (->json (s/maybe Long) {:in :header}) => (->json Long)
-        (->json (s/maybe Long) {:in :path}) => (->json Long)))
+        (->swagger (s/maybe Long) {:in :body}) => (->swagger Long)
+        (->swagger (s/maybe Long) {:in :header}) => (->swagger Long)
+        (->swagger (s/maybe Long) {:in :path}) => (->swagger Long)))
 
     (fact "s/both -> type of the first element"
-      (->json (s/both Long String))   => (->json Long))
+      (->swagger (s/both Long String))   => (->swagger Long))
 
     (fact "s/either -> type of the first element"
-      (->json (s/either Long String)) => (->json Long))
+      (->swagger (s/either Long String)) => (->swagger Long))
 
     (fact "s/named -> type of schema"
-      (->json (s/named Long "long"))  => (->json Long))
+      (->swagger (s/named Long "long"))  => (->swagger Long))
 
     (fact "s/one -> type of schema"
-      (->json [(s/one Long "s")])  => (->json [Long]))
+      (->swagger [(s/one Long "s")])  => (->swagger [Long]))
 
     (fact "s/recursive -> type of internal schema"
-      (->json (s/recursive #'Model))  => (->json #'Model))
+      (->swagger (s/recursive #'Model))  => (->swagger #'Model))
 
     (fact "s/eq -> type of class of value"
-      (->json (s/eq "kikka"))         => (->json String))
+      (->swagger (s/eq "kikka"))         => (->swagger String))
 
     (fact "s/Any -> nil"
-      (->json s/Any) => nil)))
+      (->swagger s/Any) => nil)))
 
 (fact "Describe"
   (tabular
     (fact "Basic classes"
       (let [schema (describe ?class ..desc.. :minimum ..val..)]
         (json-schema-meta schema) => {:description ..desc.. :minimum ..val..}
-        (->json schema) => (contains {:description ..desc..})))
+        (->swagger schema) => (contains {:description ..desc..})))
     ?class
     Long
     Double
@@ -107,7 +107,7 @@
   (fact "Describe Model"
     (let [schema (describe Model ..desc..)]
       (json-schema-meta schema) => {:description ..desc..}
-      (->json schema) => (contains {:description ..desc..})
+      (->swagger schema) => (contains {:description ..desc..})
       )))
 
 (facts "properties"


### PR DESCRIPTION
- renamed `json-type` to `convert-class` so that it will break at compile-time (as it's a new contract!)
- renamed `json-property` to `convert` to denote it's about conversion, not JSON values
- cleaned up internals
- class-based dispatch is now done from the protocol-based dispatch => single entrypoint to conversion!
- cleaned up README (typos, new stuff)