### PR TITLE
Use linked instead of ordered

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [clj-time "0.11.0"]
                  [org.tobereplaced/lettercase "1.0.0"]
                  [potemkin "0.4.1"]
-                 [org.flatland/ordered "1.5.3"]]
+                 [frankiesardo/linked "1.2.6"]]
   :profiles {:dev {:plugins [[lein-clojars "0.9.1"]
                              [lein-ring "0.9.7"]
                              [lein-midje "3.1.3"]

--- a/src/ring/swagger/core.clj
+++ b/src/ring/swagger/core.clj
@@ -12,7 +12,7 @@
 
             [ring.swagger.common :refer :all]
             [schema-tools.walk :as stw]
-            [flatland.ordered.set :as os]
+            [linked.core :as linked]
             [clojure.string :as string]
             [org.tobereplaced.lettercase :as lc])
   (:import (clojure.lang IMapEntry)))
@@ -95,7 +95,7 @@
           (let [schema (if (var? x) @x x)]
             (swap!
               schemas update-in [schema-name]
-              (fn [x] (conj (or x (os/ordered-set)) schema)))))
+              (fn [x] (conj (or x (linked/set)) schema)))))
         x)
       x)
     @schemas))

--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -3,7 +3,7 @@
             [schema.spec.core :as spec]
             [schema.spec.variant :as variant]
             [ring.swagger.common :as c]
-            [flatland.ordered.map :refer :all]))
+            [linked.core :as linked]))
 
 (declare properties)
 
@@ -217,7 +217,7 @@
 (defn properties
   "Take a map schema and turn them into json-schema properties.
    The result is put into collection of same type as input schema.
-   Thus ordered-map should keep the order of items. Returnes nil
+   Thus linked/map should keep the order of items. Returnes nil
    if no properties are found."
   [schema]
   {:pre [(c/plain-map? schema)]}

--- a/test/ring/swagger/common_test.clj
+++ b/test/ring/swagger/common_test.clj
@@ -1,7 +1,7 @@
 (ns ring.swagger.common-test
   (:require [midje.sweet :refer :all]
             [ring.swagger.common :refer :all]
-            [flatland.ordered.map :as om]))
+            [linked.core :as linked]))
 
 (fact "remove-empty-keys"
   (remove-empty-keys {:a nil :b false :c 0}) => {:b false :c 0})
@@ -37,4 +37,4 @@
 (fact "plain-map?"
   (plain-map? {}) => true
   (plain-map? (->ARecord 1)) => false
-  (plain-map? (om/ordered-map :a 1)) => true)
+  (plain-map? (linked/map :a 1)) => true)

--- a/test/ring/swagger/core_test.clj
+++ b/test/ring/swagger/core_test.clj
@@ -4,9 +4,9 @@
             [ring.swagger.test-utils :refer :all]
             [ring.swagger.schema :refer :all]
             [ring.swagger.core :refer :all]
-            [flatland.ordered.map :refer :all]))
+            [linked.core :as linked]))
 
-(s/defschema OrderedSchema (ordered-map
+(s/defschema OrderedSchema (linked/map
                              :id Long
                              :hot Boolean
                              :tag (s/enum :kikka :kukka)

--- a/test/ring/swagger/json_schema_test.clj
+++ b/test/ring/swagger/json_schema_test.clj
@@ -3,7 +3,7 @@
             [schema.core :as s]
             [ring.swagger.json-schema :refer :all]
             [ring.swagger.core :refer [with-named-sub-schemas]]
-            [flatland.ordered.map :refer :all])
+            [linked.core :as linked])
   (:import [java.util Date UUID]
            [org.joda.time DateTime LocalDate]
            [java.util.regex Pattern]))
@@ -144,7 +144,7 @@
                            :b java.util.Vector})) => [:a])))
 
   (fact "Keeps the order of properties intact"
-    (keys (properties (ordered-map :a String
+    (keys (properties (linked/map :a String
                                    :b String
                                    :c String
                                    :d String
@@ -155,7 +155,7 @@
     => [:a :b :c :d :e :f :g :h])
 
   (fact "Ordered-map works with sub-schemas"
-    (properties (with-named-sub-schemas (ordered-map :a String
+    (properties (with-named-sub-schemas (linked/map :a String
                                                      :b {:foo String}
                                                      :c [{:bar String}])))
     => anything)

--- a/test/ring/swagger/swagger2_test.clj
+++ b/test/ring/swagger/swagger2_test.clj
@@ -2,7 +2,7 @@
   (:require [schema.core :as s]
             [ring.swagger.swagger2 :refer :all]
             [ring.swagger.validator :as v]
-            [flatland.ordered.map :as om]
+            [linked.core :as linked]
             [ring.util.http-status :as status]
             [midje.sweet :refer :all])
   (:import [java.util Date UUID]
@@ -289,7 +289,7 @@
 
 (fact "retain :paths order, #54"
   (let [->path (fn [x] (str "/" x))
-        paths (reduce (fn [acc x] (assoc acc (->path x) {:get {}})) (om/ordered-map) (range 100))
+        paths (reduce (fn [acc x] (assoc acc (->path x) {:get {}})) (linked/map) (range 100))
         swagger {:paths paths}
         spec (swagger-json swagger)]
     (-> spec :paths keys) => (map ->path (range 100))))


### PR DESCRIPTION
Ordered keeps on allocating space after several conj and disj. This
behaviour is dangerous and not very well documented.
Linked uses a different data structure implementation that avoids this problem.

I'm obviously biased towards linked, so let me know if you have any question about it that I can clarify.