### PR TITLE
Ignore classes and s/Any in map schema keys

### DIFF
--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -235,7 +235,11 @@
   {:pre [(c/plain-map? schema)]}
   (let [props (into (empty schema)
                     (for [[k v] schema
-                          :when (c/not-predicate? k)
+                          :when (and (c/not-predicate? k)
+                                     ; Ignore s/Str and such
+                                     (not (class? k))
+                                     ; Special case to ignore s/Any
+                                     (not= s/Any k))
                           :let [key-meta (meta k)
                                 k (s/explicit-schema-key k)
                                 v (try->swagger v k key-meta)]]

--- a/test/ring/swagger/json_schema_test.clj
+++ b/test/ring/swagger/json_schema_test.clj
@@ -166,6 +166,16 @@
                        s/Keyword s/Any}))
     => [:a])
 
+  (fact "Class -keys are ignored"
+    (keys (properties {:a String
+                       s/Str s/Any}))
+    => [:a])
+
+  (fact "s/Any -keys are ignored"
+    (keys (properties {:a String
+                       s/Any s/Any}))
+    => [:a])
+
   (fact "with unknown mappings"
     (fact "by default, exception is thrown"
       (properties {:a String


### PR DESCRIPTION
Not sure if this is best approach. Another possibility would be to catch exceptions from `explicit-schema-key` and ignore keys for which it doesn't work.

Also, supporting string values as keys needs additional consideration. Is this a valid schema? Should it be supported?

```clj
(s/defschema User {"username" s/Str})
```

Fixes #77 
