### PR TITLE
Small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+* Closed Map Schemas (e.g. `s/find-extra-keys-schema` returning nil) will have `:additionalProperties` set to `false`.
+* Path-parameters are always required (in align to the spec)
+* Body-parameters are not required if wrapped in `schema.core.Maybe`
+* Cleaned up internals 
+  * `ring.swagger.swagger2/transform` -> `ring.swagger.json-schema/schema-object`
+
 ## 0.22.3 (17.1.2016)
 
 **[compare](https://github.com/metosin/ring-swagger/compare/0.22.2...0.22.3)**

--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -2,8 +2,7 @@
   (:require [schema.core :as s]
             [schema.spec.core :as spec]
             [schema.spec.variant :as variant]
-            [ring.swagger.common :as c]
-            [linked.core :as linked]))
+            [ring.swagger.common :as c]))
 
 (declare properties)
 
@@ -22,8 +21,8 @@
   schema.core.Schema
   (spec [this]
     (variant/variant-spec
-     spec/+no-precondition+
-     [{:schema schema}]))
+      spec/+no-precondition+
+      [{:schema schema}]))
   (explain [this] (s/explain schema)))
 
 (defn field
@@ -95,7 +94,7 @@
 ;;
 (def predicate-name-to-class {'integer? java.lang.Long
                               'keyword? clojure.lang.Keyword
-                              'symbol?  clojure.lang.Symbol})
+                              'symbol? clojure.lang.Symbol})
 
 (defn reference [e]
   (if-let [schema-name (s/schema-name e)]
@@ -228,9 +227,9 @@
 
 (defn properties
   "Take a map schema and turn them into json-schema properties.
-   The result is put into collection of same type as input schema.
-   Thus linked/map should keep the order of items. Returnes nil
-   if no properties are found."
+  The result is put into collection of same type as input schema.
+  Thus linked/map should keep the order of items. Returnes nil
+  if no properties are found."
   [schema]
   {:pre [(c/plain-map? schema)]}
   (let [props (into (empty schema)

--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -5,6 +5,9 @@
             [ring.swagger.common :as c]
             [ring.swagger.core :as rsc]))
 
+(defn maybe? [schema]
+  (instance? schema.core.Maybe schema))
+
 (declare properties)
 
 ; TODO: remove this in favor of passing it as options

--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -2,7 +2,8 @@
   (:require [schema.core :as s]
             [schema.spec.core :as spec]
             [schema.spec.variant :as variant]
-            [ring.swagger.common :as c]))
+            [ring.swagger.common :as c]
+            [ring.swagger.core :as rsc]))
 
 (declare properties)
 
@@ -222,7 +223,7 @@
     (reference e)))
 
 ;;
-;; Schema to Swagger Schmea definitions
+;; Schema to Swagger Schema definitions
 ;;
 
 (defn properties
@@ -251,3 +252,18 @@
     (let [v (get schema extra-key)]
       (try->swagger v s/Keyword nil))
     false))
+
+(defn schema-object
+  "Returns a JSON Schema object of a plain map schema."
+  [schema]
+  {:pre [(c/plain-map? schema)]}
+  (let [properties (properties schema)
+        additional-properties (additional-properties schema)
+        required (->> (rsc/required-keys schema)
+                      (filter (partial contains? properties))
+                      seq)]
+    (c/remove-empty-keys
+      {:type "object"
+       :properties properties
+       :additionalProperties additional-properties
+       :required required})))

--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -250,4 +250,5 @@
   {:pre [(c/plain-map? schema)]}
   (if-let [extra-key (s/find-extra-keys-schema schema)]
     (let [v (get schema extra-key)]
-      (try->swagger v s/Keyword nil))))
+      (try->swagger v s/Keyword nil))
+    false))

--- a/src/ring/swagger/schema.clj
+++ b/src/ring/swagger/schema.clj
@@ -8,16 +8,6 @@
             [ring.swagger.coerce :as coerce]
             ring.swagger.json-schema))
 
-(def Keyword  s/Keyword)
-
-(defn extract-schema-name
-  "Returns model name or nil"
-  [x] (some-> (if (or (set? x) (sequential? x)) (first x) x) s/schema-name))
-
-;;
-;; Public Api
-;;
-
 (import-vars [ring.swagger.json-schema
               field
               describe])

--- a/src/ring/swagger/swagger2.clj
+++ b/src/ring/swagger/swagger2.clj
@@ -58,7 +58,7 @@
         {:in in
          :name (name rk)
          :description ""
-         :required (s/required-key? k)}
+         :required (or (= in :path) (s/required-key? k))}
         json-schema))))
 
 (defn- default-response-description

--- a/src/ring/swagger/swagger2.clj
+++ b/src/ring/swagger/swagger2.clj
@@ -44,7 +44,7 @@
       (vector {:in :body
                :name (name (s/schema-name schema))
                :description (or (:description (jsons/->swagger schema options)) "")
-               :required (not (jsons/maybe? schema))
+               :required (not (jsons/maybe? model))
                :schema (dissoc schema-json :description)}))))
 
 (defmethod extract-parameter :default [in model options]

--- a/src/ring/swagger/swagger2.clj
+++ b/src/ring/swagger/swagger2.clj
@@ -8,13 +8,6 @@
             [ring.swagger.swagger2-schema :as schema]))
 
 ;;
-;; Support Schemas
-;;
-
-(def Anything {s/Keyword s/Any})
-(def Nothing {})
-
-;;
 ;; Schema transformations
 ;;
 
@@ -32,23 +25,11 @@
                              (keep :schema))]
     (concat body-models response-models)))
 
-(defn transform [schema]
-  (let [properties (jsons/properties schema)
-        additional-properties (jsons/additional-properties schema)
-        required (->> (rsc/required-keys schema)
-                      (filter (partial contains? properties))
-                      seq)]
-    (remove-empty-keys
-      {:type "object"
-       :properties properties
-       :additionalProperties additional-properties
-       :required required})))
-
 (defn transform-models [schemas options]
   (->> schemas
        rsc/collect-models
        (rsc/handle-duplicate-schemas (:handle-duplicate-schemas-fn options))
-       (map (juxt (comp str key) (comp transform val)))
+       (map (juxt (comp str key) (comp jsons/schema-object val)))
        (into (sorted-map))))
 
 ;;

--- a/src/ring/swagger/swagger2.clj
+++ b/src/ring/swagger/swagger2.clj
@@ -44,7 +44,7 @@
       (vector {:in :body
                :name (name (s/schema-name schema))
                :description (or (:description (jsons/->swagger schema options)) "")
-               :required true
+               :required (not (jsons/maybe? schema))
                :schema (dissoc schema-json :description)}))))
 
 (defmethod extract-parameter :default [in model options]

--- a/test/ring/swagger/json_schema_test.clj
+++ b/test/ring/swagger/json_schema_test.clj
@@ -243,7 +243,7 @@
 (facts "additional-properties"
   (fact "No additional properties"
     (additional-properties {:a s/Str})
-    => nil)
+    => false)
 
   (fact "s/Keyword"
     (additional-properties {s/Keyword s/Bool})

--- a/test/ring/swagger/schema_test.clj
+++ b/test/ring/swagger/schema_test.clj
@@ -16,7 +16,7 @@
    :b Double
    :c Long
    :d String
-   :e {:f [Keyword]
+   :e {:f [s/Keyword]
        :g #{String}
        :h #{(s/enum :kikka :kakka :kukka)}
        :i Date
@@ -109,7 +109,7 @@
         (coerce OddModel 2) => error?))))
 
 (facts "schema coercion"
-  (let [Schema {:a Long :b Double :c Boolean :d Keyword :u UUID}
+  (let [Schema {:a Long :b Double :c Boolean :d s/Keyword :u UUID}
         value  {:a "1"  :b "2.2"  :c "true"  :d "kikka" :u "77e70512-1337-dead-beef-0123456789ab"}
         target {:a 1    :b 2.2    :c true    :d :kikka  :u (UUID/fromString "77e70512-1337-dead-beef-0123456789ab")}]
 

--- a/test/ring/swagger/swagger2_test.clj
+++ b/test/ring/swagger/swagger2_test.clj
@@ -326,7 +326,6 @@
 
     (transform-operations remove-x-no-doc {:paths {"/a" {:get {:x-no-doc true}, :post {}}
                                                    "/b" {:put {:x-no-doc true}}}})))
-; {:paths {"/a" {:post {}}}}))
 
 (s/defschema SchemaA {:a s/Str})
 (s/defschema SchemaB {:b s/Str})
@@ -346,4 +345,8 @@
     {:paths {"/api/:id.json" {:get {:parameters {:path {:id String}}}}}})
   => (contains
        {:paths (just
-                 {"/api/{id}.json" (contains {:get (contains {:parameters (just [(contains {:name "id"})])})})})}))
+                 {"/api/{id}.json" (contains
+                                     {:get (contains
+                                             {:parameters (just
+                                                            [(contains
+                                                               {:name "id"})])})})})}))

--- a/test/ring/swagger/swagger2_test.clj
+++ b/test/ring/swagger/swagger2_test.clj
@@ -10,6 +10,9 @@
            [java.util.regex Pattern]
            [org.joda.time DateTime LocalDate]))
 
+(s/defschema Anything {s/Keyword s/Any})
+(s/defschema Nothing {})
+
 (s/defschema LegOfPet {:length Long})
 
 (s/defschema Pet {:id Long

--- a/test/ring/swagger/swagger2_test.clj
+++ b/test/ring/swagger/swagger2_test.clj
@@ -333,12 +333,17 @@
 
 (fact "s/either stuff is correctly named"
   (-> (swagger-json {:paths {"/ab" {:get {:parameters {:body SchemaAB}}}}})
-      :paths (get "/ab") :get :parameters first)
+      (get-in [:paths "/ab" :get :parameters 0]))
   => {:in :body
       :name "SchemaA"
       :description ""
       :required true
       :schema {:$ref "#/definitions/SchemaA"}})
+
+(fact "body wrapped in Maybe make's it optional"
+  (-> (swagger-json {:paths {"/maybe" {:post {:parameters {:body (s/maybe {:kikka s/Str})}}}}})
+      (get-in [:paths "/maybe" :post :parameters 0]))
+  => (contains {:in :body, :required false}))
 
 (fact "path-parameters with .dot extension, #82"
   (swagger-json

--- a/test/ring/swagger/swagger2_test.clj
+++ b/test/ring/swagger/swagger2_test.clj
@@ -294,6 +294,7 @@
                             :b {:type "array"
                                 :items {:type "string"}
                                 :description "B"}}
+               :additionalProperties false
                :required [:a :b]})))
 
 (fact "tags"

--- a/test/ring/swagger/swagger2_unit_test.clj
+++ b/test/ring/swagger/swagger2_unit_test.clj
@@ -14,10 +14,14 @@
 (s/defschema Tag {(s/optional-key :id) (field s/Int {:description "Unique identifier for the tag"})
                   (s/optional-key :name) (field s/Str {:description "Friendly name for the tag"})})
 
-(s/defschema Category {(s/optional-key :id) (field s/Int {:description "Category unique identifier" :minimum "0.0" :maximum "100.0"})
+(s/defschema Category {(s/optional-key :id) (field s/Int {:description "Category unique identifier"
+                                                          :minimum "0.0"
+                                                          :maximum "100.0"})
                        (s/optional-key :name) (field s/Str {:description "Name of the category"})})
 
-(s/defschema Pet {:id (field s/Int {:description "Unique identifier for the Pet" :minimum "0.0" :maximum "100.0"})
+(s/defschema Pet {:id (field s/Int {:description "Unique identifier for the Pet"
+                                    :minimum "0.0"
+                                    :maximum "100.0"})
                   :name (field s/Str {:description "Friendly name of the pet"})
                   (s/optional-key :category) (field Category {:description "Category the pet is in"})
                   (s/optional-key :photoUrls) (field [s/Str] {:description "Image URLs"})
@@ -80,9 +84,9 @@
 ;;
 
 (fact "transform simple schemas"
-  (transform Tag) => Tag'
-  (transform Category) => Category'
-  (transform Pet) => Pet')
+  (jsons/schema-object Tag) => Tag'
+  (jsons/schema-object Category) => Category'
+  (jsons/schema-object Pet) => Pet')
 
 (s/defschema RootModel
   {:sub {:foo Long}})
@@ -166,7 +170,7 @@
       (keys
         (transform-models
           [(rsc/with-named-sub-schemas ReturnValue)]
-          +options+)) => ["Boundary" "ReturnValue"])))
+        +options+)) => ["Boundary" "ReturnValue"]))
 
 (s/defschema Query {:id Long (s/optional-key :q) String})
 (s/defschema Path {:p Long})
@@ -492,11 +496,11 @@
                 :b (->InvalidElement)}]
 
     (fact "fail by default"
-      (transform schema) => (throws IllegalArgumentException))
+      (jsons/schema-object schema) => (throws IllegalArgumentException))
 
     (fact "drops bad fields from both properties & required"
       (binding [jsons/*ignore-missing-mappings* true]
-        (transform schema)
+        (jsons/schema-object schema)
 
         => {:type "object"
             :properties {:a {:type "string"}}

--- a/test/ring/swagger/swagger2_unit_test.clj
+++ b/test/ring/swagger/swagger2_unit_test.clj
@@ -113,7 +113,7 @@
 (fact "transform-models"
   (transform-models [Pet] +options+) => {"Pet" Pet'
                                          "Tag" Tag'
-                                         "Category" Category'}
+                                         "Category" Category'})
 
 (s/defschema Foo (s/enum :a :b))
 (s/defschema Bar {:key Foo})

--- a/test/ring/swagger/swagger2_unit_test.clj
+++ b/test/ring/swagger/swagger2_unit_test.clj
@@ -38,7 +38,8 @@
                      :format "int64"
                      :description "Unique identifier for the tag"}
                 :name {:type "string"
-                       :description "Friendly name for the tag"}}})
+                       :description "Friendly name for the tag"}}
+   :additionalProperties false})
 
 (def Category'
   {:type "object"
@@ -48,7 +49,8 @@
                      :minimum "0.0"
                      :maximum "100.0"}
                 :name {:type "string"
-                       :description "Name of the category"}}})
+                       :description "Name of the category"}}
+   :additionalProperties false})
 
 (def Pet'
   {:type "object"
@@ -70,7 +72,8 @@
                        :items {:$ref "#/definitions/Tag"}}
                 :status {:type "string"
                          :description "pet status in the store"
-                         :enum [:pending :sold :available]}}})
+                         :enum [:pending :sold :available]}}
+   :additionalProperties false})
 
 ;;
 ;; Facts
@@ -122,6 +125,7 @@
     (transform-models [Bar] +options+) => {"Bar" {:type "object"
                                                   :properties {:key {:enum [:b :a]
                                                                      :type "string"}}
+                                                  :additionalProperties false
                                                   :required [:key]}})
 
   (fact "nested schemas"
@@ -137,14 +141,17 @@
       {"Nested" {:type "object"
                  :properties {:address {:$ref "#/definitions/NestedAddress"}
                               :id {:type "string"}}
+                 :additionalProperties false
                  :required [:id :address]}
        "NestedAddress" {:type "object"
                         :properties {:country {:enum [:fi :pl]
                                                :type "string"}
                                      :street {:$ref "#/definitions/NestedAddressStreet"}}
+                        :additionalProperties false
                         :required [:country :street]}
        "NestedAddressStreet" {:type "object"
                               :properties {:name {:type "string"}}
+                              :additionalProperties false
                               :required [:name]}})
 
     (fact "nested named sub-schemas"
@@ -290,6 +297,7 @@
 
       => {:type "object"
           :properties {:foo {:type "string"}}
+          :additionalProperties false
           :required [:foo]})
 
     (fact "array of anonymous map as response model is named and refers to correct definition"
@@ -301,6 +309,7 @@
       => {:type "object"
           :properties {:bar {:type "integer"
                              :format "int64"}}
+          :additionalProperties false
           :required [:bar]})))
 
 ;;
@@ -352,9 +361,11 @@
   (transform-models [Foo Bar] +options+)
   => {"Bar" {:type "object"
              :properties {:foo {:$ref "#/definitions/Foo"}}
+             :additionalProperties false
              :required [:foo]}
       "Foo" {:type "object"
              :properties {:bar {:$ref "#/definitions/Bar"}}
+             :additionalProperties false
              :required [:bar]}})
 
 ;;
@@ -451,7 +462,8 @@
                                                  :description "Tags assigned to this pet"}
                                           :status {:enum [:pending :sold :available]
                                                    :type "string"
-                                                   :description "pet status in the store"}}}
+                                                   :description "pet status in the store"}}
+                             :additionalProperties false}
                       "Category" {:type "object"
                                   :properties {:id {:type "integer"
                                                     :format "int64"
@@ -459,13 +471,15 @@
                                                     :minimum "0.0"
                                                     :maximum "100.0"}
                                                :name {:type "string"
-                                                      :description "Name of the category"}}}
+                                                      :description "Name of the category"}}
+                                  :additionalProperties false}
                       "Tag" {:type "object"
                              :properties {:id {:type "integer"
                                                :format "int64"
                                                :description "Unique identifier for the tag"}
                                           :name {:type "string"
-                                                 :description "Friendly name for the tag"}}}
+                                                 :description "Friendly name for the tag"}}
+                             :additionalProperties false}
                       "PetError" {:type "object"
                                   :properties {:message {:type "string"}}
                                   :required [:message]}}}))
@@ -486,6 +500,7 @@
 
         => {:type "object"
             :properties {:a {:type "string"}}
+            :additionalProperties false
             :required [:a]}))))
 
 (fact "collectionFormat"


### PR DESCRIPTION
* Closed Map Schemas (e.g. `s/find-extra-keys-schema` returning nil) will have `:additionalProperties` set to `false`.
* Path-parameters are always required (in align to the spec)
* Body-parameters are not required if wrapped in `schema.core.Maybe`
* Cleaned up internals 
  * `ring.swagger.swagger2/transform` -> `ring.swagger.json-schema/schema-object`