### PR TITLE
Field & x-nullable -enchancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
                :title "Ankka"}}))
 ```
 
+* Better support for nillable fields via `x-nullable` [standard hack](https://github.com/OAI/OpenAPI-Specification/issues/229), fixes fixes [#97](https://github.com/metosin/ring-swagger/issues/97)
+
 * updated dependencies:
 
 ```clj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## UNRELEASED
 
+* Map-schema swagger-metadata is set to target schema-object, not for the `$ref` of it, fixes [#96](https://github.com/metosin/ring-swagger/issues/96).
+* Better support for additional json-schema meta-data via `ring.swagger.json-schema/field`:
+
+```clj
+(s/defschema Required
+  (rsjs/field
+    {:name s/Str
+     :title s/Str
+     :address (rsjs/field
+                (rsjs/field s/Str {:description "description here"})
+                {:description "Streename"
+                 :example "Ankkalinna 1"})}
+    {:minProperties 1
+     :description "I'm required"
+     :example {:name "Iines"
+               :title "Ankka"}}))
+```
+
 * updated dependencies:
 
 ```clj

--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -161,8 +161,9 @@
   schema.core.Maybe
   (convert [e {:keys [in]}]
     (let [schema (->swagger (:schema e))]
-      (if (#{:query :formData} in)
-        (assoc schema :allowEmptyValue true)
+      (condp contains? in
+        #{:query :formData} (assoc schema :allowEmptyValue true)
+        #{nil :body} (assoc schema :x-nullable true)
         schema)))
 
   schema.core.Both

--- a/src/ring/swagger/swagger2.clj
+++ b/src/ring/swagger/swagger2.clj
@@ -43,9 +43,9 @@
     (let [schema-json (jsons/->swagger model options)]
       (vector {:in "body"
                :name (name (s/schema-name schema))
-               :description (or (:description (jsons/->swagger schema options)) "")
+               :description (or (:description (jsons/json-schema-meta schema)) "")
                :required (not (jsons/maybe? model))
-               :schema (dissoc schema-json :description)}))))
+               :schema schema-json}))))
 
 (defmethod extract-parameter :default [in model options]
   (if model

--- a/test/ring/swagger/json_schema_test.clj
+++ b/test/ring/swagger/json_schema_test.clj
@@ -15,33 +15,33 @@
 
 (facts "type transformations"
   (facts "java types"
-    (->swagger Integer)   => {:type "integer" :format "int32"}
-    (->swagger Long)      => {:type "integer" :format "int64"}
-    (->swagger Double)    => {:type "number" :format "double"}
-    (->swagger Number)    => {:type "number" :format "double"}
-    (->swagger Symbol)    => {:type "string"}
-    (->swagger String)    => {:type "string"}
-    (->swagger Boolean)   => {:type "boolean"}
-    (->swagger Date)      => {:type "string" :format "date-time"}
-    (->swagger DateTime)  => {:type "string" :format "date-time"}
+    (->swagger Integer) => {:type "integer" :format "int32"}
+    (->swagger Long) => {:type "integer" :format "int64"}
+    (->swagger Double) => {:type "number" :format "double"}
+    (->swagger Number) => {:type "number" :format "double"}
+    (->swagger Symbol) => {:type "string"}
+    (->swagger String) => {:type "string"}
+    (->swagger Boolean) => {:type "boolean"}
+    (->swagger Date) => {:type "string" :format "date-time"}
+    (->swagger DateTime) => {:type "string" :format "date-time"}
     (->swagger LocalDate) => {:type "string" :format "date"}
-    (->swagger Pattern)   => {:type "string" :format "regex"}
-    (->swagger #"[6-9]")  => {:type "string" :pattern "[6-9]"}
-    (->swagger UUID)      => {:type "string" :format "uuid"})
+    (->swagger Pattern) => {:type "string" :format "regex"}
+    (->swagger #"[6-9]") => {:type "string" :pattern "[6-9]"}
+    (->swagger UUID) => {:type "string" :format "uuid"})
 
   (fact "schema types"
-    (->swagger s/Int)     => {:type "integer" :format "int64"}
-    (->swagger s/Str)     => {:type "string"}
-    (->swagger s/Symbol)  => {:type "string"}
-    (->swagger s/Inst)    => {:type "string" :format "date-time"}
-    (->swagger s/Num)     => {:type "number" :format "double"})
+    (->swagger s/Int) => {:type "integer" :format "int64"}
+    (->swagger s/Str) => {:type "string"}
+    (->swagger s/Symbol) => {:type "string"}
+    (->swagger s/Inst) => {:type "string" :format "date-time"}
+    (->swagger s/Num) => {:type "number" :format "double"})
 
   (fact "containers"
-    (->swagger [Long])    => {:type "array" :items {:format "int64" :type "integer"}}
-    (->swagger #{Long})   => {:type "array" :items {:format "int64" :type "integer"} :uniqueItems true})
+    (->swagger [Long]) => {:type "array" :items {:format "int64" :type "integer"}}
+    (->swagger #{Long}) => {:type "array" :items {:format "int64" :type "integer"} :uniqueItems true})
 
   (facts "nil"
-    (->swagger nil)       => nil)
+    (->swagger nil) => nil)
 
   (facts "unknowns"
     (fact "throw exception by default"
@@ -58,7 +58,7 @@
   (fact "schema predicates"
     (fact "s/enum"
       (->swagger (s/enum :kikka :kakka)) => {:type "string" :enum [:kikka :kakka]}
-      (->swagger (s/enum 1 2 3))         => {:type "integer" :format "int64" :enum (seq #{1 2 3})})
+      (->swagger (s/enum 1 2 3)) => {:type "integer" :format "int64" :enum (seq #{1 2 3})})
 
     (fact "s/maybe"
       (fact "uses wrapped value by default"
@@ -72,30 +72,30 @@
         (->swagger (s/maybe Long) {:in :path}) => (->swagger Long)))
 
     (fact "s/both -> type of the first element"
-      (->swagger (s/both Long String))   => (->swagger Long))
+      (->swagger (s/both Long String)) => (->swagger Long))
 
     (fact "s/either -> type of the first element"
       (->swagger (s/either Long String)) => (->swagger Long))
 
     (fact "s/named -> type of schema"
-      (->swagger (s/named Long "long"))  => (->swagger Long))
+      (->swagger (s/named Long "long")) => (->swagger Long))
 
     (fact "s/one -> type of schema"
-      (->swagger [(s/one Long "s")])  => (->swagger [Long]))
+      (->swagger [(s/one Long "s")]) => (->swagger [Long]))
 
     (fact "s/recursive -> type of internal schema"
-      (->swagger (s/recursive #'Model))  => (->swagger #'Model))
+      (->swagger (s/recursive #'Model)) => (->swagger #'Model))
 
     (fact "s/eq -> type of class of value"
-      (->swagger (s/eq "kikka"))         => (->swagger String))
+      (->swagger (s/eq "kikka")) => (->swagger String))
 
     (fact "s/Any"
       (fact "defaults to nil"
-        (->swagger s/Any)                 => nil
-        (->swagger s/Any {:in :body})     => nil
-        (->swagger s/Any {:in :header})   => {:type "string"}
-        (->swagger s/Any {:in :path})     => {:type "string"}
-        (->swagger s/Any {:in :query})    => {:type "string", :allowEmptyValue true}
+        (->swagger s/Any) => nil
+        (->swagger s/Any {:in :body}) => nil
+        (->swagger s/Any {:in :header}) => {:type "string"}
+        (->swagger s/Any {:in :path}) => {:type "string"}
+        (->swagger s/Any {:in :query}) => {:type "string", :allowEmptyValue true}
         (->swagger s/Any {:in :formData}) => {:type "string", :allowEmptyValue true}))
 
     (fact "s/conditional"
@@ -156,7 +156,25 @@
   (fact "Describe Model"
     (let [schema (describe Model ..desc..)]
       (json-schema-meta schema) => {:description ..desc..}
-      (->swagger schema) => (contains {:description ..desc..}))))
+      (->swagger schema) =not=> (contains {:description ..desc..}))))
+
+(fact "field"
+  (fact "on maps"
+    (let [schema (s/schema-with-name
+                   (field {(s/optional-key :name) s/Str
+                           (s/optional-key :title) s/Str}
+                          {:minProperties 1})
+                   "schema")]
+
+      (fact "$ref's are stripped of extra metadata"
+        (->swagger schema) => {:$ref "#/definitions/schema"})
+
+      (fact "extra metadata is present on schema objects"
+        (schema-object schema) => (contains
+                                    {:properties {:name {:type "string"}
+                                                  :title {:type "string"}}
+                                     :minProperties 1
+                                     :additionalProperties false})))))
 
 (fact "leiPredicate evaluation"
   (tabular
@@ -215,19 +233,19 @@
 
   (fact "Keeps the order of properties intact"
     (keys (properties (linked/map :a String
-                                   :b String
-                                   :c String
-                                   :d String
-                                   :e String
-                                   :f String
-                                   :g String
-                                   :h String)))
+                                  :b String
+                                  :c String
+                                  :d String
+                                  :e String
+                                  :f String
+                                  :g String
+                                  :h String)))
     => [:a :b :c :d :e :f :g :h])
 
   (fact "Ordered-map works with sub-schemas"
     (properties (with-named-sub-schemas (linked/map :a String
-                                                     :b {:foo String}
-                                                     :c [{:bar String}])))
+                                                    :b {:foo String}
+                                                    :c [{:bar String}])))
     => anything)
 
   (fact "referenced record-schemas"

--- a/test/ring/swagger/json_schema_test.clj
+++ b/test/ring/swagger/json_schema_test.clj
@@ -61,13 +61,14 @@
       (->swagger (s/enum 1 2 3)) => {:type "integer" :format "int64" :enum (seq #{1 2 3})})
 
     (fact "s/maybe"
-      (fact "uses wrapped value by default"
-        (->swagger (s/maybe Long)) => (->swagger Long))
+      (fact "uses wrapped value by default with x-nullable true"
+        (->swagger (s/maybe Long)) => (assoc (->swagger Long) :x-nullable true))
       (fact "adds allowEmptyValue when for query and formData as defined by the spec"
         (->swagger (s/maybe Long) {:in :query}) => (assoc (->swagger Long) :allowEmptyValue true)
         (->swagger (s/maybe Long) {:in :formData}) => (assoc (->swagger Long) :allowEmptyValue true))
+      (fact "uses wrapped value by default with x-nullable true with body"
+        (->swagger (s/maybe Long) {:in :body}) => (assoc (->swagger Long) :x-nullable true))
       (fact "uses wrapped value for other parameters"
-        (->swagger (s/maybe Long) {:in :body}) => (->swagger Long)
         (->swagger (s/maybe Long) {:in :header}) => (->swagger Long)
         (->swagger (s/maybe Long) {:in :path}) => (->swagger Long)))
 

--- a/test/ring/swagger/swagger2_unit_test.clj
+++ b/test/ring/swagger/swagger2_unit_test.clj
@@ -379,7 +379,8 @@
 (fact "recursive"
   (transform-models [Foo Bar] +options+)
   => {"Bar" {:type "object"
-             :properties {:foo {:$ref "#/definitions/Foo"}}
+             :properties {:foo {:$ref "#/definitions/Foo"
+                                :x-nullable true}}
              :additionalProperties false
              :required [:foo]}
       "Foo" {:type "object"

--- a/test/ring/swagger/swagger2_unit_test.clj
+++ b/test/ring/swagger/swagger2_unit_test.clj
@@ -23,7 +23,7 @@
                                     :minimum "0.0"
                                     :maximum "100.0"})
                   :name (field s/Str {:description "Friendly name of the pet"})
-                  (s/optional-key :category) (field Category {:description "Category the pet is in"})
+                  (s/optional-key :category) Category
                   (s/optional-key :photoUrls) (field [s/Str] {:description "Image URLs"})
                   (s/optional-key :tags) (field [Tag] {:description "Tags assigned to this pet"})
                   (s/optional-key :status) (field (s/enum :available :pending :sold) {:description "pet status in the store"})})
@@ -64,8 +64,7 @@
                      :description "Unique identifier for the Pet"
                      :minimum "0.0"
                      :maximum "100.0"}
-                :category {:$ref "#/definitions/Category"
-                           :description "Category the pet is in"}
+                :category {:$ref "#/definitions/Category"}
                 :name {:type "string"
                        :description "Friendly name of the pet"}
                 :photoUrls {:type "array"
@@ -475,8 +474,7 @@
                                                :maximum "100.0"}
                                           :name {:type "string"
                                                  :description "Friendly name of the pet"}
-                                          :category {:$ref "#/definitions/Category"
-                                                     :description "Category the pet is in"}
+                                          :category {:$ref "#/definitions/Category"}
                                           :photoUrls {:type "array"
                                                       :items {:type "string"}
                                                       :description "Image URLs"}


### PR DESCRIPTION
* `ring.swagger.json-schema/field` set's the meta on the schema-object, not on the $ref. Fixes #96
* also, fixed #97 with `x-nullable` fields.