### PR TITLE
swagger-ui #91 - any type fix

### DIFF
--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -193,7 +193,8 @@
   schema.core.AnythingSchema
   (convert [_ {:keys [in] :as opts}]
     (if (and in (not= :body in))
-      (->swagger (s/maybe s/Str) opts)))
+      (->swagger (s/maybe s/Str) opts)
+      {}))
 
   schema.core.ConditionalSchema
   (convert [e _]


### PR DESCRIPTION
Any type (s/Any) is converted to an empty json schema in response schema and in body parameter schema. Empty schema: {} should match anything see http://stackoverflow.com/questions/16826128/why-is-this-json-schema-invalid-using-any-type. Other in parameters are converted as previously. Note: i have not run the tests.