### PR TITLE
Add schema helper function for schema.core.Record

### DIFF
--- a/src/ring/swagger/schema.clj
+++ b/src/ring/swagger/schema.clj
@@ -44,3 +44,6 @@
       (if (error? result)
         (throw+ (assoc result :type ::validation))
         result))))
+
+(defn class-schema [klass]
+  (s/schema-with-name (:schema (su/class-schema klass)) (.getSimpleName klass)))


### PR DESCRIPTION
Hi! 
I am having trouble when I use s/defrecord (issue #103):
```
(s/defrecord User [id :- s/Str
                   name :- s/Str])           

{:responses {200 {:schema User :description "Found it!"}
             404 {:description "Ohnoes."}}}                           
```
but ring-swagger throws:
```
500 : {"type":"unknown-exception","class":"java.lang.IllegalArgumentException"} http://localhost:3000/swagger.json
```
- Reason
In `JsonSchema` Protocol:
1. `s/defrecord` type is Class.
2. `convert-class` is not supported `schema.core.Record`.

- Simple solution
Pass the schema as plain map in `schema.core.Record` using `schema.utils/class-schema`.
```clojure
(require '[schema.utils :as su])
{:responses {200 {:schema (:schema (su/class-schmea User)) :description "Found it!"}
             404 {:description "Ohnoes."}}}
```
But plain map doesn't have name. So I Add schema name using `schema.core/schema-with-name`.

Usage with compojure-api:
```clojure
(ns luminus-swagger.routes.services
  (:require [ring.util.http-response :refer :all]
            [compojure.api.sweet :refer :all]
            [ring.swagger.schema :as rss]
            [schema.core :as s]))

(s/defrecord User [id :- s/Str
                   name :- s/Str])

(defapi service-routes
  {:swagger {:ui "/swagger-ui"
             :spec "/swagger.json"
             :data {:info {:version "1.0.0"
                           :title "Sample API"
                           :description "Sample Services"}}}}
  (context "/users" []
    :tags ["user"]

    (POST "/" []
      :return (rss/class-schema User)
      :body        [user (rss/class-schema User)]
      :summary     "create user"
      (ok))))
```
