### PR TITLE
Support schemas with postconditions on query parameters

### DIFF
--- a/src/ring/swagger/swagger2.clj
+++ b/src/ring/swagger/swagger2.clj
@@ -1,6 +1,7 @@
 (ns ring.swagger.swagger2
   (:require [clojure.string :as str]
             [schema.core :as s]
+            [schema-tools.core :as stc]
             [plumbing.core :as p]
             [ring.swagger.common :as common]
             [ring.swagger.json-schema :as rsjs]
@@ -51,7 +52,7 @@
 
 (defmethod extract-parameter :default [in model options]
   (if model
-    (for [[k v] (-> model common/value-of rsc/strict-schema)
+    (for [[k v] (-> model common/value-of stc/schema-value rsc/strict-schema)
           :when (s/specific-key? k)
           :let [rk (s/explicit-schema-key k)
                 json-schema (rsjs/->swagger v options)]

--- a/test/ring/swagger/swagger2_test.clj
+++ b/test/ring/swagger/swagger2_test.clj
@@ -538,19 +538,45 @@
 
 (def Adult (s/constrained Person #(>= (:age %) 18)))
 
-(fact "query parameters with constrained schema, #104"
+(fact "query parameters with ..., #104"
 
-  (let [swagger {:paths {"/people" {:get {:parameters {:query Adult}
-                                          :responses {200 {:schema s/Str}}}}}}]
-    (swagger2/swagger-json swagger)
-    => (contains
-         {:definitions {}
-          :paths {"/people" {:get {:parameters [{:in "query"
-                                                 :name "age"
-                                                 :description ""
-                                                 :required true
-                                                 :type "integer"
-                                                 :format "int64"}]
-                                   :responses {200 {:description ""
-                                                    :schema {:type "string"}}}}}}})
-    (validate swagger) => nil))
+  (fact "constrained schema"
+    (let [swagger {:paths {"/people" {:get {:parameters {:query Adult}
+                                            :responses {200 {:schema s/Str}}}}}}]
+      (swagger2/swagger-json swagger)
+      => (contains
+           {:definitions {}
+            :paths {"/people" {:get {:parameters [{:in "query"
+                                                   :name "age"
+                                                   :description ""
+                                                   :required true
+                                                   :type "integer"
+                                                   :format "int64"}]
+                                     :responses {200 {:description ""
+                                                      :schema {:type "string"}}}}}}})
+      (validate swagger) => nil))
+  (fact "top-level maybe schema"
+    (let [swagger {:paths {"/" {:get {:parameters {:query (s/maybe {:a s/Str})}}}}}]
+      (swagger2/swagger-json swagger)
+      => (contains
+          {:definitions {}
+           :paths {"/" {:get {:parameters [{:in "query"
+                                            :name "a"
+                                            :description ""
+                                            :required true
+                                            :type "string"}]
+                              :responses {:default {:description ""}}}}}})
+      (validate swagger) => nil))
+  (fact "nested maybe schema"
+    (let [swagger {:paths {"/" {:get {:parameters {:query {:a (s/maybe s/Str)}}}}}}]
+      (swagger2/swagger-json swagger)
+      => (contains
+           {:definitions {}
+            :paths {"/" {:get {:parameters [{:in "query"
+                                             :name "a"
+                                             :description ""
+                                             :required true
+                                             :type "string"
+                                             :allowEmptyValue true}]
+                               :responses {:default {:description ""}}}}}})
+          (validate swagger) => nil)))

--- a/test/ring/swagger/swagger2_test.clj
+++ b/test/ring/swagger/swagger2_test.clj
@@ -533,3 +533,24 @@
                                                   :schema {:type "string"}}}}}}})
 
     (validate swagger) => nil))
+
+(s/defschema Person {:age s/Int})
+
+(def Adult (s/constrained Person #(>= (:age %) 18)))
+
+(fact "query parameters with constrained schema, #104"
+
+  (let [swagger {:paths {"/people" {:get {:parameters {:query Adult}
+                                          :responses {200 {:schema s/Str}}}}}}]
+    (swagger2/swagger-json swagger)
+    => (contains
+         {:definitions {}
+          :paths {"/people" {:get {:parameters [{:in "query"
+                                                 :name "age"
+                                                 :description ""
+                                                 :required true
+                                                 :type "integer"
+                                                 :format "int64"}]
+                                   :responses {200 {:description ""
+                                                    :schema {:type "string"}}}}}}})
+    (validate swagger) => nil))

--- a/test/ring/swagger/swagger2_unit_test.clj
+++ b/test/ring/swagger/swagger2_unit_test.clj
@@ -218,6 +218,29 @@
          :type "integer"
          :format "int32"}])
 
+  (fact "schemas wtih postconditions are supported in ..."
+    (s/defschema Polygon {:sides s/Int})
+    (s/defschema Triangle (s/constrained Polygon #(= (:sides %) 3)))
+
+    (fact ":query parameters"
+      (swagger2/convert-parameters
+        {:query Triangle} {})
+      => [{:name "sides"
+           :in "query"
+           :description ""
+           :required true
+           :type "integer"
+           :format "int64"}])
+
+    (fact ":body parameters"
+      (swagger2/convert-parameters
+        {:body Triangle} {})
+      => [{:name "Triangle"
+           :in "body"
+           :description ""
+           :required true
+           :schema {:$ref "#/definitions/Polygon"}}]))
+
   (fact "anonymous schemas can be used with ..."
 
     (fact ":query-parameters"


### PR DESCRIPTION
In some cases, the schema records include a few more keys besides the model
definition itself. For example, schemas with postconditions include the
keys `:postconditions` and `:post-name`. In cases like that, the keys
need to be excluded before the conversion to Swagger spec.

Since the keys unrelated to the model definition were not being ignored,
the use of schemas with postconditions in the query parameters was causing
an exception to be raised.
The fields are now excluded by using `schema-tools.core/schema-value`
before the conversion to Swagger spec.

Closes #104