### PR TITLE
Use keyword for ns require

### DIFF
--- a/src/ring/swagger/swagger2_schema.clj
+++ b/src/ring/swagger/swagger2_schema.clj
@@ -1,6 +1,6 @@
 (ns ring.swagger.swagger2-schema
   "Schemas that Ring-Swagger expects from it's clients"
-  (require [schema.core :as s]))
+  (:require [schema.core :as s]))
 
 (defn opt [x] (s/optional-key x))
 (def X- (s/pred #(re-find #"x-" (name %)) ":x-.*"))


### PR DESCRIPTION
This change makes ring-swagger compile under Clojure 1.9.0-alpha11, in which `ns` forms are now spec'd