### PR TITLE
Do not (re-)load swagger-schema.json from the Internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,7 @@ you can do the following:
 ## Validating the Swagger Spec
 
 The generated full spec can be validated against the [Swagger JSON Schema](https://raw.githubusercontent.com/reverb/swagger-spec/master/schemas/v2.0/schema.json)
-with the help of [scjsv](https://github.com/metosin/scjsv). **NOTE** currently loads the JSON Schema files for the internet, 
-from http://json-schema.org/draft-04/schema.
+with the help of [scjsv](https://github.com/metosin/scjsv).
 
 ```clojure
 (require '[ring.swagger.validator :as v])

--- a/resources/ring/swagger/swagger-schema.json
+++ b/resources/ring/swagger/swagger-schema.json
@@ -1,6 +1,5 @@
 {
   "title": "A JSON Schema for Swagger 2.0 API.",
-  "id": "http://swagger.io/v2/schema.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "required": [


### PR DESCRIPTION
This is done by unsetting the id field in `swagger-schema.json`.

At first I thought the right way to do this would be to [use inline dereferencing](https://github.com/metosin/scjsv/pull/3). Now I'm thinking that ring-swagger would need inline dereferencing only accidentally - the real problem is that scjsv does not know that the URL of the schema is the same as its id.

There are two solutions: to remove the id (like in this PR) or to teach scjsv about the URL by creating a JsonLoadingFactory with this schema preloaded for the right URL.