### PR TITLE
Support java.time coercion

### DIFF
--- a/src/ring/swagger/extension.clj
+++ b/src/ring/swagger/extension.clj
@@ -1,0 +1,16 @@
+(ns ring.swagger.extension)
+
+(defmacro defextension
+  "Define a wrapper that will conditionally execute the body based on the
+  value of test."
+  [name test]
+  `(defmacro ~name [& body#]
+     (when ~test
+       `(do ~@body#))))
+
+(defextension java-time
+  (every?
+    (fn [c] (try (resolve c) (catch Exception _)))
+    '[java.time.Instant
+      java.time.LocalDate
+      java.time.LocalTime]))

--- a/src/ring/swagger/json.clj
+++ b/src/ring/swagger/json.clj
@@ -1,7 +1,8 @@
 (ns ring.swagger.json
   (:require [cheshire.generate :refer [add-encoder]]
             [schema.utils :as su]
-            [ring.swagger.coerce :as coerce])
+            [ring.swagger.coerce :as coerce]
+            [ring.swagger.extension :as extension])
   (:import [com.fasterxml.jackson.core JsonGenerator]
            [schema.utils ValidationError]
            [java.util Date]
@@ -34,3 +35,16 @@
 (add-encoder Pattern
   (fn [x ^JsonGenerator jg]
     (.writeString jg (coerce/unparse-pattern x))))
+
+(extension/java-time
+  (add-encoder java.time.Instant
+    (fn [^java.time.Instant x ^JsonGenerator jg]
+      (.writeString jg (.toString x))))
+
+  (add-encoder java.time.LocalDate
+    (fn [^java.time.LocalDate x ^JsonGenerator jg]
+      (.writeString jg (.toString x))))
+
+  (add-encoder java.time.LocalTime
+    (fn [^java.time.LocalTime x ^JsonGenerator jg]
+      (.writeString jg (.toString x)))))

--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -3,7 +3,8 @@
             [schema.spec.core :as spec]
             [schema.spec.variant :as variant]
             [ring.swagger.common :as common]
-            [ring.swagger.core :as rsc]))
+            [ring.swagger.core :as rsc]
+            [ring.swagger.extension :as extension]))
 
 (defn maybe? [schema]
   (instance? schema.core.Maybe schema))
@@ -99,6 +100,11 @@
 (defmethod convert-class org.joda.time.LocalDate [_ _] {:type "string" :format "date"})
 (defmethod convert-class org.joda.time.LocalTime [_ _] {:type "string" :format "time"})
 (defmethod convert-class java.util.regex.Pattern [_ _] {:type "string" :format "regex"})
+
+(extension/java-time
+  (defmethod convert-class java.time.Instant   [_ _] {:type "string" :format "date-time"})
+  (defmethod convert-class java.time.LocalDate [_ _] {:type "string" :format "date"})
+  (defmethod convert-class java.time.LocalTime [_ _] {:type "string" :format "time"}))
 
 (defmethod convert-class :default [e _]
   (if-not *ignore-missing-mappings*

--- a/test/ring/swagger/coerce_test.clj
+++ b/test/ring/swagger/coerce_test.clj
@@ -2,6 +2,7 @@
   (:require [midje.sweet :refer :all]
             [schema.core :as s]
             [ring.swagger.coerce :as rsc]
+            [ring.swagger.extension :as extension]
             [schema.coerce :as sc])
   (:import [org.joda.time LocalDate DateTime LocalTime]
            [java.util Date UUID]))
@@ -26,7 +27,21 @@
       ((cooerce LocalTime) "10:23:37.456") => (partial instance? LocalTime))
 
     (fact "UUID"
-      ((cooerce UUID) "77e70512-1337-dead-beef-0123456789ab") => (partial instance? UUID))))
+      ((cooerce UUID) "77e70512-1337-dead-beef-0123456789ab") => (partial instance? UUID))
+
+    (extension/java-time
+      (fact "java.time"
+        (fact "Instant with and without millis"
+          ((cooerce java.time.Instant) "2014-02-18T18:25:37.456Z") => (partial instance? java.time.Instant)
+          ((cooerce java.time.Instant) "2014-02-18T18:25:37Z") => (partial instance? java.time.Instant))
+
+        (fact "LocalDate"
+          ((cooerce java.time.LocalDate) "2014-02-19") => (partial instance? java.time.LocalDate))
+
+        (fact "LocalTime"
+          ((cooerce java.time.LocalTime) "10:23") => (partial instance? java.time.LocalTime)
+          ((cooerce java.time.LocalTime) "10:23:37") => (partial instance? java.time.LocalTime)
+          ((cooerce java.time.LocalTime) "10:23:37.456") => (partial instance? java.time.LocalTime))))))
 
 (fact "query coercions"
   (let [coerce (rsc/coercer :query)]

--- a/test/ring/swagger/extension_test.clj
+++ b/test/ring/swagger/extension_test.clj
@@ -11,7 +11,7 @@
       (disabled
         (swap! evals conj :a)
         (swap! evals conj :b)
-        :c) => nil?
+        :c) => nil
       @evals => empty?)
     (fact "do evaluate the body if the extension test is truthy"
       (enabled
@@ -20,7 +20,18 @@
         :f) => :f
       @evals => [:d :e]))
   (fact "undefined vars/classes are ignored in disabled extensions"
-    (resolve 'a) => nil?
+    (resolve 'a) => nil
     (disabled (a)) =not=> (throws Exception)
     (resolve 'dummy.Class) => (throws ClassNotFoundException)
     (disabled (dummy.Class)) =not=> (throws Exception)))
+
+(fact "java-time extension"
+  (let [java-time (try
+                    (resolve 'java.time.Instant)
+                    (catch Exception _))]
+    (if java-time
+      (fact "runs the enclosed form"
+        (extension/java-time :a) => :a)
+      (fact "skips the enclosed form"
+        (extension/java-time :a) => nil
+        (resolve 'java.time.Instant) => (throws ClassNotFoundException)))))

--- a/test/ring/swagger/extension_test.clj
+++ b/test/ring/swagger/extension_test.clj
@@ -1,0 +1,26 @@
+(ns ring.swagger.extension-test
+  (:require [midje.sweet :refer :all]
+            [ring.swagger.extension :as extension]))
+
+(extension/defextension enabled (true? true))
+(extension/defextension disabled (true? false))
+
+(fact "defextension wrappers"
+  (let [evals (atom [])]
+    (fact "do not evaluate the body if the extension test is falsey"
+      (disabled
+        (swap! evals conj :a)
+        (swap! evals conj :b)
+        :c) => nil?
+      @evals => empty?)
+    (fact "do evaluate the body if the extension test is truthy"
+      (enabled
+        (swap! evals conj :d)
+        (swap! evals conj :e)
+        :f) => :f
+      @evals => [:d :e]))
+  (fact "undefined vars/classes are ignored in disabled extensions"
+    (resolve 'a) => nil?
+    (disabled (a)) =not=> (throws Exception)
+    (resolve 'dummy.Class) => (throws ClassNotFoundException)
+    (disabled (dummy.Class)) =not=> (throws Exception)))

--- a/test/ring/swagger/json_schema_test.clj
+++ b/test/ring/swagger/json_schema_test.clj
@@ -5,6 +5,7 @@
             [plumbing.fnk.pfnk :as pfnk]
             [ring.swagger.json-schema :as rsjs]
             [ring.swagger.core :as rsc]
+            [ring.swagger.extension :as extension]
             [linked.core :as linked])
   (:import [java.util Date UUID Currency]
            [org.joda.time DateTime LocalDate LocalTime]
@@ -37,7 +38,12 @@
     (rsjs/->swagger LocalTime) => {:type "string" :format "time"}
     (rsjs/->swagger Pattern) => {:type "string" :format "regex"}
     (rsjs/->swagger #"[6-9]") => {:type "string" :pattern "[6-9]"}
-    (rsjs/->swagger UUID) => {:type "string" :format "uuid"})
+    (rsjs/->swagger UUID) => {:type "string" :format "uuid"}
+    (extension/java-time
+      (rsjs/->swagger java.time.Instant) => {:type "string" :format "date-time"}
+      (rsjs/->swagger java.time.LocalDate) => {:type "string" :format "date"}
+      (rsjs/->swagger java.time.LocalTime) => {:type "string" :format "time"}))
+
 
   (fact "schema types"
     (rsjs/->swagger s/Int) => {:type "integer" :format "int64"}
@@ -174,7 +180,10 @@
     LocalTime
     Pattern
     UUID
-    clojure.lang.Keyword)
+    clojure.lang.Keyword
+    (extension/java-time java.time.Instant)
+    (extension/java-time java.time.LocalDate)
+    (extension/java-time java.time.LocalTime))
 
   (fact "Describe Model"
     (let [schema (rsjs/describe Model ..desc..)]

--- a/test/ring/swagger/schema_test.clj
+++ b/test/ring/swagger/schema_test.clj
@@ -3,6 +3,7 @@
             [schema.core :as s]
             [cheshire.core :as cheshire]
             [clj-time.core :as t]
+            [ring.swagger.extension :as extension]
             [ring.swagger.schema :as schema]
             ring.swagger.json)
   (:import [java.util Date UUID]
@@ -66,7 +67,27 @@
       jmodel =not=> model)
 
     (fact "coerce! makes models match"
-      (pattern-to-str (schema/coerce! AllTypes jmodel)) => model)))
+      (pattern-to-str (schema/coerce! AllTypes jmodel)) => model))
+
+  (extension/java-time
+    (let [types {:i java.time.Instant
+                 :ld java.time.LocalDate
+                 :lt java.time.LocalTime}
+          model {:i (java.time.Instant/now)
+                 :ld (java.time.LocalDate/now)
+                 :lt (java.time.LocalTime/now)}
+          json (cheshire/generate-string model)
+          jmodel (cheshire/parse-string json true)]
+
+      (fact "json can be parsed"
+        json => truthy
+        jmodel => truthy)
+
+      (fact "by default, models don't match"
+        jmodel =not=> model)
+
+      (fact "coerce! makes models match"
+        (schema/coerce! types jmodel) => model))))
 
 (fact "date-time coercion"
   (fact "with millis"

--- a/test/ring/swagger/swagger2_test.clj
+++ b/test/ring/swagger/swagger2_test.clj
@@ -3,6 +3,7 @@
             [ring.swagger.swagger2 :as swagger2]
             [ring.swagger.swagger2-full-schema :as full-schema]
             [ring.swagger.json-schema :as rsjs]
+            [ring.swagger.extension :as extension]
             [ring.swagger.validator :as validator]
             [linked.core :as linked]
             [ring.util.http-status :as status]
@@ -140,6 +141,14 @@
 
 (fact "more complete spec"
   (validate a-complete-swagger) => nil)
+
+(extension/java-time
+  (fact "spec with java.time"
+    (let [model {:i java.time.Instant
+                 :ld java.time.LocalDate
+                 :lt java.time.LocalTime}
+          swagger {:paths {"/time" {:post {:parameters {:body model}}}}}]
+      (validate swagger) => nil)))
 
 (defrecord InvalidElement [])
 


### PR DESCRIPTION
Taking a crack at #107 - support for `java.time.Instant`, `java.time.LocalDate`, and
`java.time.LocalTime`.

I haven't written tests for `java.time`-specific extensions yet... should these tests be conditionally evaluated as well, to only run tests if testing in an environment that has java 1.8+?
