### PR TITLE
Swagger-ui 3.0.17 and new SwaggerUI configuration JSON

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                    :dependencies [[org.clojure/clojure "1.8.0"]
                                   [midje "1.9.0"]
                                   [ring-mock "0.1.5"]
-                                  [metosin/ring-swagger-ui "3.0.17"]
+                                  [metosin/ring-swagger-ui "3.9.0"]
                                   [javax.servlet/javax.servlet-api "3.1.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}}

--- a/src/ring/swagger/swagger_ui.clj
+++ b/src/ring/swagger/swagger_ui.clj
@@ -13,12 +13,12 @@
 (defn- json-key [k]
   (lc/mixed (name k)))
 
-(defn conf-js [req opts]
+(defn config-json [req opts]
   (let [swagger-docs (swagger/join-paths (swagger/context req) (:swagger-docs opts "/swagger.json"))
         conf (-> opts
                  (dissoc :swagger-docs :path)
                  (assoc :url swagger-docs))]
-    (str "window.API_CONF = " (json/generate-string conf {:key-fn json-key}) ";")))
+    (json/generate-string conf {:key-fn json-key})))
 
 
 (defn- serve [{:keys [path root] :or {path "/", root "swagger-ui"} :as options}]
@@ -29,7 +29,7 @@
               (when-let [req-path (get-path uri request-uri)]
                 (condp = req-path
                   "" (http-response/found (swagger/join-paths request-uri "index.html"))
-                  "conf.js" (http-response/content-type (http-response/ok (conf-js req options)) "application/javascript")
+                  "config.json" (http-response/content-type (http-response/ok (config-json req options)) "application/json")
                   (http-response/resource-response (str root "/" req-path))))))]
     (fn
       ([request]

--- a/src/ring/swagger/swagger_ui.clj
+++ b/src/ring/swagger/swagger_ui.clj
@@ -20,6 +20,8 @@
                  (assoc :url swagger-docs))]
     (json/generate-string conf {:key-fn json-key})))
 
+(defn conf-js [req opts]
+  (str "window.API_CONF = " (config-json req opts) ";"))
 
 (defn- serve [{:keys [path root] :or {path "/", root "swagger-ui"} :as options}]
   (let [f (fn [{request-uri :uri :as req}]
@@ -29,6 +31,9 @@
               (when-let [req-path (get-path uri request-uri)]
                 (condp = req-path
                   "" (http-response/found (swagger/join-paths request-uri "index.html"))
+                  ;; Swagger-UI 2
+                  "conf.js" (http-response/content-type (http-response/ok (conf-js req options)) "application/javascript")
+                  ;; Swagger-UI 3
                   "config.json" (http-response/content-type (http-response/ok (config-json req options)) "application/json")
                   (http-response/resource-response (str root "/" req-path))))))]
     (fn


### PR DESCRIPTION
Works, but I think the old one is better... this doesn't currently support old versions. Perhaps middleware should provide both config.json and conf.js for old ring-swagger-ui?