### PR TITLE
Support s/Num in query params coercion

### DIFF
--- a/src/ring/swagger/coerce.clj
+++ b/src/ring/swagger/coerce.clj
@@ -81,6 +81,13 @@
       (catch Exception _ x))
     x))
 
+(defn string->number [^String x]
+  (if (string? x)
+    (if (re-find #"^-?\d+\.?\d*$" x) ; https://stackoverflow.com/a/12285023
+      (read-string x)
+      x)
+    x))
+
 (defn string->uuid [^String x]
   (if (string? x)
     (try
@@ -113,14 +120,17 @@
                       Keyword sc/string->keyword
                       s/Uuid string->uuid
                       s/Int (cond-matcher
-                              string? string->long
-                              number? sc/safe-long-cast)
-                      Long (cond-matcher
                              string? string->long
                              number? sc/safe-long-cast)
+                      Long (cond-matcher
+                            string? string->long
+                            number? sc/safe-long-cast)
                       Double (cond-matcher
-                               string? string->double
-                               number? number->double)
+                              string? string->double
+                              number? number->double)
+                      s/Num (cond-matcher
+                             string? string->number
+                             number? identity)
                       Boolean string->boolean})
 
 (defn json-schema-coercion-matcher

--- a/test/ring/swagger/coerce_test.clj
+++ b/test/ring/swagger/coerce_test.clj
@@ -62,6 +62,13 @@
       ((coerce Double) "1") => 1.0
       ((coerce Double) "invalid") => "invalid")
 
+    (fact "s/Num"
+      ((coerce s/Num) 1) => 1
+      ((coerce s/Num) 1.0) => 1.0
+      ((coerce s/Num) "1") => 1
+      ((coerce s/Num) "1.0") => 1.0
+      ((coerce s/Num) "invalid") => "invalid")
+
     (fact "Boolean"
       ((coerce Boolean) true) => true
       ((coerce Boolean) "true") => true


### PR DESCRIPTION
Adds support for s/Num in query parameter coercion.

Goal is to have support for following case in Compojure-API which is now failing to coerce from string to number:

```clojure
:query-params [{address_lat :- s/Num nil}
               {address_lon :- s/Num nil}]
```

Related to [issue in compojure-api](https://github.com/metosin/compojure-api/issues/317).