### PR TITLE
Allow meta descriptions for response bodies

### DIFF
--- a/src/ring/swagger/swagger2.clj
+++ b/src/ring/swagger/swagger2.clj
@@ -87,7 +87,9 @@
                                                                     (->> (for [[k v] headers]
                                                                            [k (rsjs/->swagger v options)])
                                                                          (into {}))))))
-                          (update-in [:description] #(or % (default-response-description k options)))
+                          (update-in [:description] #(or %
+                                                         (:description (rsjs/json-schema-meta v))
+                                                         (default-response-description k options)))
                           common/remove-empty-keys))]
     (if-not (empty? responses)
       responses

--- a/test/ring/swagger/swagger2_test.clj
+++ b/test/ring/swagger/swagger2_test.clj
@@ -602,3 +602,14 @@
 
     (get-in endpoint [:parameters 0]) => (contains {:name "kikka/kukka"})
     (get-in response [:properties]) => (contains {:olipa/kerran {:type "string"}})))
+
+
+(fact "Meta-description of body responses are considered"
+  (let [swagger {:paths {"/meta" {:get {:parameters {:query {:kikka/kukka String}}
+                                       :responses {200 (rsjs/describe {:body {:kikka/kukka String}}
+                                                                      "A meta description")}}}
+                         "/direct" {:get {:parameters {:query {:kikka/kukka String}}
+                                          :responses {200 {:body {:kikka/kukka String}
+                                                           :description "A direct description"}}}}}}]
+    (get-in (swagger2/swagger-json swagger) [:paths "/meta" :get :responses 200]) => (contains {:description "A meta description"})
+    (get-in (swagger2/swagger-json swagger) [:paths "/direct" :get :responses 200]) => (contains {:description "A direct description"})))


### PR DESCRIPTION
When describing body responses for a route definition consider the
metadata from the json-schema namespace.

Fixes #127