### PR TITLE
oneOf => x-oneOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,8 +351,8 @@ You can require `ring.swagger.json-schema-dirty` namespace to get JSON Schema di
 
 | Clojure | JSON Schema | Sample  |
 | --------|-------|:------------:|
-| `(s/conditional pred X pred Y pred Z)` | oneOf: *type of X*, *type of Y*, *type of Z*
-| `(s/if pred X Y)` | oneOf: *type of X*, *type of Y*
+| `(s/conditional pred X pred Y pred Z)` | x-oneOf: *type of X*, *type of Y*, *type of Z*
+| `(s/if pred X Y)` | x-oneOf: *type of X*, *type of Y*
 
 ### Schema coercion
 

--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -215,11 +215,11 @@
 
   schema.core.ConditionalSchema
   (convert [e _]
-    {:type "void" :oneOf (vec (keep (comp ->swagger second) (:preds-and-schemas e)))})
+    {:type "void" :x-oneOf (vec (keep (comp ->swagger second) (:preds-and-schemas e)))})
 
   schema.core.CondPre
   (convert [e _]
-    {:type "void" :oneOf (mapv ->swagger (:schemas e))})
+    {:type "void" :x-oneOf (mapv ->swagger (:schemas e))})
 
   schema.core.Constrained
   (convert [e _]

--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -215,11 +215,11 @@
 
   schema.core.ConditionalSchema
   (convert [e _]
-    {:type "void" :x-oneOf (vec (keep (comp ->swagger second) (:preds-and-schemas e)))})
+    {:x-oneOf (vec (keep (comp ->swagger second) (:preds-and-schemas e)))})
 
   schema.core.CondPre
   (convert [e _]
-    {:type "void" :x-oneOf (mapv ->swagger (:schemas e))})
+    {:x-oneOf (mapv ->swagger (:schemas e))})
 
   schema.core.Constrained
   (convert [e _]

--- a/test/ring/swagger/json_schema_test.clj
+++ b/test/ring/swagger/json_schema_test.clj
@@ -130,11 +130,11 @@
 
     (fact "s/conditional"
       (rsjs/->swagger (s/conditional (constantly true) Long (constantly false) String))
-      => {:type "void" :oneOf [(rsjs/->swagger Long) (rsjs/->swagger String)]}
+      => {:type "void" :x-oneOf [(rsjs/->swagger Long) (rsjs/->swagger String)]}
 
       (fact "invalid values are removed"
         (rsjs/->swagger (s/conditional (constantly true) Long (constantly false) Currency))
-        => {:type "void" :oneOf [(rsjs/->swagger Long)]}))
+        => {:type "void" :x-oneOf [(rsjs/->swagger Long)]}))
 
     (fact "s/constrained"
       (rsjs/->swagger (s/constrained Long even?))
@@ -142,11 +142,11 @@
 
     (fact "s/if"
       (rsjs/->swagger (s/if (constantly true) Long String))
-      => {:type "void" :oneOf [(rsjs/->swagger Long) (rsjs/->swagger String)]})
+      => {:type "void" :x-oneOf [(rsjs/->swagger Long) (rsjs/->swagger String)]})
 
     (fact "s/cond-pre"
       (rsjs/->swagger (s/cond-pre Model [s/Str]))
-      => {:type "void" :oneOf [(rsjs/->swagger Model) (rsjs/->swagger [s/Str])]})
+      => {:type "void" :x-oneOf [(rsjs/->swagger Model) (rsjs/->swagger [s/Str])]})
     ))
 
 (fact "Optional-key default metadata"

--- a/test/ring/swagger/json_schema_test.clj
+++ b/test/ring/swagger/json_schema_test.clj
@@ -130,11 +130,11 @@
 
     (fact "s/conditional"
       (rsjs/->swagger (s/conditional (constantly true) Long (constantly false) String))
-      => {:type "void" :x-oneOf [(rsjs/->swagger Long) (rsjs/->swagger String)]}
+      => {:x-oneOf [(rsjs/->swagger Long) (rsjs/->swagger String)]}
 
       (fact "invalid values are removed"
         (rsjs/->swagger (s/conditional (constantly true) Long (constantly false) Currency))
-        => {:type "void" :x-oneOf [(rsjs/->swagger Long)]}))
+        => {:x-oneOf [(rsjs/->swagger Long)]}))
 
     (fact "s/constrained"
       (rsjs/->swagger (s/constrained Long even?))
@@ -142,11 +142,11 @@
 
     (fact "s/if"
       (rsjs/->swagger (s/if (constantly true) Long String))
-      => {:type "void" :x-oneOf [(rsjs/->swagger Long) (rsjs/->swagger String)]})
+      => {:x-oneOf [(rsjs/->swagger Long) (rsjs/->swagger String)]})
 
     (fact "s/cond-pre"
       (rsjs/->swagger (s/cond-pre Model [s/Str]))
-      => {:type "void" :x-oneOf [(rsjs/->swagger Model) (rsjs/->swagger [s/Str])]})
+      => {:x-oneOf [(rsjs/->swagger Model) (rsjs/->swagger [s/Str])]})
     ))
 
 (fact "Optional-key default metadata"

--- a/test/ring/swagger/swagger2_test.clj
+++ b/test/ring/swagger/swagger2_test.clj
@@ -26,6 +26,9 @@
 (s/defschema Parrot {:name String
                      :type {:name String}})
 
+(s/defschema Turtle {:name String
+                     :tags  (s/if map? {s/Keyword s/Keyword} [String])})
+
 (s/defschema NotFound {:message s/Str})
 
 (defn validate-swagger-json [swagger & [options]]
@@ -128,7 +131,26 @@
                                            :query {:x (s/maybe String)}}
                               :responses {200 {:description "ok"
                                                :schema {:sum (s/maybe Long)}}
-                                          :default {:description "error"}}}}}})
+                                          :default {:description "error"}}}}
+           "/api/turtle" {:get {:parameters {:body Turtle
+                                             :query (merge Anything {:x Long :y Long})
+                                             :path Nothing
+                                             :header Anything
+                                             :formData Anything}
+                                :responses {200 {:description "ok"
+                                                 :schema {:sum Long}}
+                                            :default {:description "error"
+                                                      :schema {:code Long}}}}
+                          :post {:parameters {:body #{Turtle}
+                                              :query (merge Anything {:x Long :y Long})}
+                                 :responses {200 {:schema {:sum Long}}
+                                             :default {:schema {:code Long}
+                                                       :headers {:location String}}}}
+                          :put {:parameters {:body [(s/maybe Turtle)]
+                                             :query {:x (s/maybe String)}}
+                                :responses {200 {:description "ok"
+                                                 :schema {:sum (s/maybe Long)}}
+                                            :default {:description "error"}}}}}})
 
 ;;
 ;; facts


### PR DESCRIPTION
```
Swagger2 JSON Schema is defined using oneOf, but does not support it: https://github.com/OAI/OpenAPI-Specification/issues/57
```
(from #clojurians slack)

Swagger2 is a subset of JSON Schema, and does not include oneOf, anyOf, allOf.
OpenAPI v3 does.

An alternative is to use `x-oneOf`, `x-anyOf`, `x-allOf` for Swagger2.

related: https://github.com/metosin/ring-swagger/issues/85