### PR TITLE
Fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: clojure
 lein: 2.9.1
 script: lein do clean, all midje, all check
 jdk:
-  - oraclejdk8
+  - openjdk8
   - oraclejdk11
 cache:
   directories:


### PR DESCRIPTION
`oraclejdk8` does not seem to work due to licensing issues, let's try
`openjdk8`. Surely it's close enough to Oracle's JDK?

* https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/5