### PR TITLE
Fixes schema-object :title parsing

### DIFF
--- a/src/ring/swagger/json_schema.clj
+++ b/src/ring/swagger/json_schema.clj
@@ -286,7 +286,7 @@
   [schema]
   (if (common/plain-map? schema)
     (let [properties (properties schema)
-          title (if (not (s/schema-name schema)) (common/title schema))
+          title (common/title schema)
           additional-properties (additional-properties schema)
           meta (json-schema-meta schema)
           required (some->> (rsc/required-keys schema)

--- a/test/ring/swagger/swagger2_test.clj
+++ b/test/ring/swagger/swagger2_test.clj
@@ -317,7 +317,8 @@
     (fact "keyword to primitive mapping"
       spec => (has-definition
                 'Kikka
-                {:type "object"
+                {:title "Kikka"
+                 :type "object"
                  :properties {:a {:type "string"}}
                  :additionalProperties {:type "string"}
                  :required [:a]}))
@@ -325,7 +326,8 @@
     (fact "keyword to model mapping"
       spec => (has-definition
                 'Kukka
-                {:type "object"
+                {:title "Kukka"
+                 :type "object"
                  :properties {:a {:type "string"}}
                  :additionalProperties {:$ref "#/definitions/Kikka"}
                  :required [:a]}))
@@ -333,7 +335,8 @@
     (fact "just additional properties"
       spec => (has-definition
                 'Kakka
-                {:type "object"
+                {:title "Kakka"
+                 :type "object"
                  :additionalProperties {:$ref "#/definitions/Kukka"}}))))
 
 (fact "extra meta-data to properties"
@@ -346,7 +349,8 @@
 
     spec => (has-definition
               'Kikka
-              {:type "object"
+              {:title "Kikka"
+               :type "object"
                :properties {:a {:type "string"
                                 :description "A"}
                             :b {:type "array"
@@ -431,7 +435,8 @@
 
     (swagger2/swagger-json swagger)
     => (contains
-         {:definitions {"Required" {:type "object"
+         {:definitions {"Required" {:title "Required"
+                                    :type "object"
                                     :description "I'm required"
                                     :example {:name "Iines"
                                               :title "Ankka"}
@@ -441,7 +446,8 @@
                                                  :title {:type "string"}
                                                  :address {:$ref "#/definitions/RequiredAddress"}}
                                     :additionalProperties false}
-                        "RequiredAddress" {:type "object"
+                        "RequiredAddress" {:title "RequiredAddress"
+                                           :type "object"
                                            :description "Streename"
                                            :example "Ankkalinna 1"
                                            :properties {:street {:type "string"
@@ -467,7 +473,8 @@
 
     (swagger2/swagger-json swagger)
     => (contains
-         {:definitions {"OptionalMaybe" {:type "object"
+         {:definitions {"OptionalMaybe" {:title "OptionalMaybe"
+                                         :type "object"
                                          :properties {:a {:type "string"}
                                                       :b {:type "string" :x-nullable true}
                                                       :c {:type "string" :x-nullable true}}

--- a/test/ring/swagger/swagger2_unit_test.clj
+++ b/test/ring/swagger/swagger2_unit_test.clj
@@ -38,7 +38,8 @@
 ;;
 
 (def Tag'
-  {:type "object"
+  {:title "Tag"
+   :type "object"
    :properties {:id {:type "integer"
                      :format "int64"
                      :description "Unique identifier for the tag"}
@@ -47,7 +48,8 @@
    :additionalProperties false})
 
 (def Category'
-  {:type "object"
+  {:title "Category"
+   :type "object"
    :properties {:id {:type "integer"
                      :format "int64"
                      :description "Category unique identifier"
@@ -58,7 +60,8 @@
    :additionalProperties false})
 
 (def Pet'
-  {:type "object"
+  {:title "Pet"
+   :type "object"
    :required [:id :name]
    :properties {:id {:type "integer"
                      :format "int64"
@@ -126,7 +129,8 @@
   (swagger2/transform-models [Baz] +options+) => {})
 
 (fact "nested record-schemas are inlined"
-  (swagger2/transform-models [Bar] +options+) => {"Bar" {:type "object"
+  (swagger2/transform-models [Bar] +options+) => {"Bar" {:title "Bar"
+                                                         :type "object"
                                                          :properties {:key {:enum [:b :a]
                                                                             :type "string"}}
                                                          :additionalProperties false
@@ -140,18 +144,21 @@
                                    :street {:name s/Str}}})
     (swagger2/transform-models [(rsc/with-named-sub-schemas Nested)] +options+)
 
-    => {"Nested" {:type "object"
+    => {"Nested" {:title "Nested"
+                  :type "object"
                   :properties {:address {:$ref "#/definitions/NestedAddress"}
                                :id {:type "string"}}
                   :additionalProperties false
                   :required [:id :address]}
-        "NestedAddress" {:type "object"
+        "NestedAddress" {:title "NestedAddress"
+                         :type "object"
                          :properties {:country {:enum [:fi :pl]
                                                 :type "string"}
                                       :street {:$ref "#/definitions/NestedAddressStreet"}}
                          :additionalProperties false
                          :required [:country :street]}
-        "NestedAddressStreet" {:type "object"
+        "NestedAddressStreet" {:title "NestedAddressStreet"
+                               :type "object"
                                :properties {:name {:type "string"}}
                                :additionalProperties false
                                :required [:name]}})
@@ -336,7 +343,8 @@
             body-schema-name (last (re-find #"\#\/definitions\/(.+)$" body-schema-ref))]
         (get definitions body-schema-name))
 
-      => {:type "object"
+      => {:title "Body18115"
+          :type "object"
           :properties {:foo {:type "string"}}
           :additionalProperties false
           :required [:foo]})
@@ -347,7 +355,8 @@
             response-schema-name (last (re-find #"\#\/definitions\/(.+)$" response-schema-ref))]
         (get definitions response-schema-name))
 
-      => {:type "object"
+      => {:title "Response18116"
+          :type "object"
           :properties {:bar {:type "integer"
                              :format "int64"}}
           :additionalProperties false
@@ -400,12 +409,14 @@
 
 (fact "recursive"
   (swagger2/transform-models [Foo Bar] +options+)
-  => {"Bar" {:type "object"
+  => {"Bar" {:title "Bar"
+             :type "object"
              :properties {:foo {:$ref "#/definitions/Foo"
                                 :x-nullable true}}
              :additionalProperties false
              :required [:foo]}
-      "Foo" {:type "object"
+      "Foo" {:title "Foo"
+             :type "object"
              :properties {:bar {:$ref "#/definitions/Bar"}}
              :additionalProperties false
              :required [:bar]}})
@@ -490,7 +501,8 @@
                                                                             :description "mutant header"}}}
                                                     404 {:description "fail"
                                                          :schema {:$ref "#/definitions/PetError"}}}}}}
-        :definitions {"Pet" {:type "object"
+        :definitions {"Pet" {:title "Pet"
+                             :type "object"
                              :required [:id :name]
                              :properties {:id {:type "integer"
                                                :format "int64"
@@ -510,7 +522,8 @@
                                                    :type "string"
                                                    :description "pet status in the store"}}
                              :additionalProperties false}
-                      "Category" {:type "object"
+                      "Category" {:title "Category"
+                                  :type "object"
                                   :properties {:id {:type "integer"
                                                     :format "int64"
                                                     :description "Category unique identifier"
@@ -519,14 +532,16 @@
                                                :name {:type "string"
                                                       :description "Name of the category"}}
                                   :additionalProperties false}
-                      "Tag" {:type "object"
+                      "Tag" {:title "Tag"
+                             :type "object"
                              :properties {:id {:type "integer"
                                                :format "int64"
                                                :description "Unique identifier for the tag"}
                                           :name {:type "string"
                                                  :description "Friendly name for the tag"}}
                              :additionalProperties false}
-                      "PetError" {:type "object"
+                      "PetError" {:title "PetError"
+                                  :type "object"
                                   :properties {:message {:type "string"}}
                                   :required [:message]
                                   :additionalProperties {}}}}))


### PR DESCRIPTION
[c74f255#277](https://github.com/metosin/ring-swagger/commit/c74f2557f6b8cceb5f09afda2b59231a646d8be6#diff-6023182e07bc1306d3389ce607e9ac30594dc2c39f399583857822c0a985b2c4L277) changed the title sourcing from allowing either the schema's :name or a :title parameter from the schema's meta to effectively blocking use of the :title parameter at all. This change allows what seems to have been the intended functionality of having common/title set the :title parameter in all use cases.

Working on verifying this change but posting this ahead of further work to see if this project is still alive.
Please let me know if you are accepting any PRs.